### PR TITLE
Fix: ajustar padding inferior para evitar superposicion con BottomNav (cards de activity_home)

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -74,7 +74,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingBottom="80dp">
+            android:paddingBottom="96dp"
+            android:clipToPadding="false">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/categories_recycler_view"


### PR DESCRIPTION
<img width="417" height="285" alt="image" src="https://github.com/user-attachments/assets/20528fc3-2285-4e0b-9321-2a1ab947b662" />
