### PR TITLE
Fix/mostrar error de registro

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -25,10 +25,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Run Unit Tests
+        # This ensures all unit tests pass before building the APK
+        run: ./gradlew :app:testDebugUnitTest
+
       - name: Build with Gradle
         # Running 'assembleDebug' ensures the app compiles.
-        # You can also use './gradlew check' to run tests and lint.
-        run: ./gradlew assembleDebug
+        run: ./gradlew :app:assembleDebug
 
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4

--- a/app/src/main/java/com/example/myapplication/data/repository/AuthRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/AuthRepository.java
@@ -172,7 +172,8 @@ public class AuthRepository {
             @Override
             public void onFailure(Call<T> call, Throwable t) {
                 activeCalls.remove(call);
-                callback.onError(errorParser.getFailureMessage(t, R.string.error_network_generic));
+                // Ahora usamos el fallbackErrorResId específico de la acción en lugar de uno genérico de red
+                callback.onError(errorParser.getFailureMessage(t, fallbackErrorResId));
             }
         });
     }

--- a/app/src/main/java/com/example/myapplication/ui/auth/SignupFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/auth/SignupFragment.java
@@ -1,6 +1,8 @@
 package com.example.myapplication.ui.auth;
 
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,11 +17,13 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class SignupFragment extends BaseAuthFragment {
 
+    private TextInputLayout emailInputLayout;
     private TextInputEditText emailEditText;
     private MaterialButton registerWithEmailButton;
     private MaterialButton classicRegisterButton;
@@ -36,6 +40,7 @@ public class SignupFragment extends BaseAuthFragment {
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        emailInputLayout = view.findViewById(R.id.signup_email_layout);
         emailEditText = view.findViewById(R.id.signup_email_edit_text);
         registerWithEmailButton = view.findViewById(R.id.signup_with_email_button);
         classicRegisterButton = view.findViewById(R.id.signup_classic_button);
@@ -54,16 +59,25 @@ public class SignupFragment extends BaseAuthFragment {
         classicRegisterButton.setOnClickListener(v ->
                 navController.navigate(R.id.action_signupFragment_to_classicRegisterFragment));
 
+        setupTextWatchers();
+
         viewModel.getRequestOtpState().observe(getViewLifecycleOwner(), state -> {
             registerWithEmailButton.setEnabled(!state.isLoading);
             classicRegisterButton.setEnabled(!state.isLoading);
             emailEditText.setEnabled(!state.isLoading);
             progressIndicator.setVisibility(state.isLoading ? View.VISIBLE : View.GONE);
 
+            // Limpiamos el error visual al empezar una nueva carga
+            if (state.isLoading) {
+                emailInputLayout.setError(null);
+            }
+
             if (state.error != null) {
-                showError(state.error.resolve(requireContext()));
+                String errorMsg = state.error.resolve(requireContext());
+                emailInputLayout.setError(errorMsg);
                 viewModel.requestOtpErrorConsumed();
             }
+
             if (state.navigateToOtpCode) {
                 String email = emailEditText.getText() != null
                         ? emailEditText.getText().toString().trim() : "";
@@ -75,16 +89,34 @@ public class SignupFragment extends BaseAuthFragment {
         });
     }
 
+    private void setupTextWatchers() {
+        emailEditText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                emailInputLayout.setError(null);
+            }
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+    }
+
     private void startOtpSignup() {
         String email = emailEditText.getText() != null
                 ? emailEditText.getText().toString().trim() : "";
         String emailError = AuthInputValidator.validateEmail(requireContext(), email);
-        if (emailError != null) { showError(emailError); return; }
+        if (emailError != null) { 
+            emailInputLayout.setError(emailError);
+            return; 
+        }
+        emailInputLayout.setError(null);
         viewModel.requestSignupOtp(email);
     }
 
     @Override
     public void onDestroyView() {
+        emailInputLayout = null;
         emailEditText = null;
         registerWithEmailButton = null;
         classicRegisterButton = null;

--- a/app/src/main/java/com/example/myapplication/util/NetworkErrorParser.java
+++ b/app/src/main/java/com/example/myapplication/util/NetworkErrorParser.java
@@ -25,11 +25,15 @@ public class NetworkErrorParser {
      * Parses an HTTP error response into a UiMessage.
      * Returns a StringMessage with the server's error text when available,
      * or a ResMessage with the fallback resource ID otherwise.
-     * No Context required — localization happens in the UI layer.
      */
     public UiMessage getErrorMessage(Response<?> response, int fallbackResId) {
         if (response == null) {
             return UiMessage.from(fallbackResId);
+        }
+
+        // Si es un error 500 (Internal Server Error), usamos un mensaje amigable
+        if (response.code() == 500) {
+            return UiMessage.from(R.string.error_internal_server);
         }
 
         try (ResponseBody errorBody = response.errorBody()) {
@@ -59,9 +63,6 @@ public class NetworkErrorParser {
 
     /**
      * Converts a network failure throwable into a UiMessage.
-     * Returns resource-ID-based messages for known failure types (no connection, timeout),
-     * or a StringMessage with the exception's localized message as fallback.
-     * No Context required — localization happens in the UI layer.
      */
     public UiMessage getFailureMessage(Throwable t, int fallbackResId) {
         if (t == null) return UiMessage.from(fallbackResId);

--- a/app/src/main/res/layout/fragment_otp_signup_code.xml
+++ b/app/src/main/res/layout/fragment_otp_signup_code.xml
@@ -40,6 +40,7 @@
                 android:textColor="?attr/colorPrimary" />
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/otp_signup_code_layout"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="forgot_password">¿Olvidaste tu contraseña?</string>
     <string name="sign_up_button">Registrarse</string>
     <string name="error_login_failed_default">No se pudo iniciar sesión.</string>
-    <string name="error_network_generic">Error de red</string>
+    <string name="error_network_generic">Error de red. Verificá tu conexión o la URL del servidor.</string>
 
     <string name="logout">Cerrar sesión</string>
     <string name="error_invalid_config">Configuración del servidor inválida. Revisá los Ajustes.</string>
@@ -70,7 +70,7 @@
     <string name="forgot_password_new_hint">Ingresá tu nueva contraseña para acceder a tu cuenta.</string>
     <string name="forgot_password_save_button">Guardar contraseña</string>
     <string name="signup_button">Registrarse</string>
-    <string name="error_no_connection">No se pudo establecer conexión con el servidor. Verificá tu internet.</string>
+    <string name="error_no_connection">No se pudo establecer conexión con el servidor. Verificá tu internet o la dirección IP.</string>
     <string name="error_timeout">La conexión expiró. Reintentá en unos momentos.</string>
     <string name="error_load_activities">No se pudieron cargar las actividades.</string>
     <string name="error_load_featured">No se pudieron cargar las actividades destacadas.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="error_invalid_dni">El DNI debe tener entre 7 y 10 dígitos.</string>
     <string name="error_invalid_otp">Ingresá un OTP válido de 6 dígitos.</string>
     <string name="error_register_failed_default">No se pudo completar el registro.</string>
-    <string name="error_signup_otp_request_default">No se pudo enviar el código de registro.</string>
+    <string name="error_signup_otp_request_default">En este momento no puede realizarse el envío del mail. Por favor, reintentá más tarde.</string>
     <string name="error_signup_otp_resend_default">No se pudo reenviar el código de registro.</string>
     <string name="error_signup_otp_verify_default">No se pudo verificar el código de registro.</string>
     <string name="error_signup_complete_default">No se pudo completar el registro con OTP.</string>
@@ -77,4 +77,5 @@
     <string name="free_label">Gratis</string>
     <string name="home_menu_logout">Cerrar sesión</string>
     <string name="action_theme_toggle">Cambiar tema</string>
+    <string name="error_internal_server">Ocurrió un error en el servidor. Por favor, reintentá más tarde.</string>
 </resources>

--- a/app/src/test/java/com/example/myapplication/data/usecase/OtpSignupUseCaseTest.java
+++ b/app/src/test/java/com/example/myapplication/data/usecase/OtpSignupUseCaseTest.java
@@ -1,0 +1,110 @@
+package com.example.myapplication.data.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.myapplication.data.common.RepositoryCallback;
+import com.example.myapplication.data.common.UiMessage;
+import com.example.myapplication.data.model.LoginResponse;
+import com.example.myapplication.data.model.OtpResponse;
+import com.example.myapplication.data.repository.AuthRepository;
+import com.example.myapplication.data.repository.SessionRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class OtpSignupUseCaseTest {
+
+    @Mock
+    private AuthRepository authRepository;
+
+    @Mock
+    private SessionRepository sessionRepository;
+
+    @Mock
+    private RepositoryCallback<OtpResponse> otpCallback;
+
+    @Mock
+    private RepositoryCallback<LoginResponse> loginCallback;
+
+    private OtpSignupUseCase otpSignupUseCase;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        otpSignupUseCase = new OtpSignupUseCase(authRepository, sessionRepository);
+    }
+
+    @Test
+    public void requestOtp_callsRepository() {
+        otpSignupUseCase.requestOtp("test@mail.com", otpCallback);
+        verify(authRepository).requestSignupOtp(eq("test@mail.com"), eq(otpCallback));
+    }
+
+    @Test
+    public void resendOtp_callsRepository() {
+        otpSignupUseCase.resendOtp("test@mail.com", otpCallback);
+        verify(authRepository).resendSignupOtp(eq("test@mail.com"), eq(otpCallback));
+    }
+
+    @Test
+    public void verifyOtp_callsRepository() {
+        otpSignupUseCase.verifyOtp("test@mail.com", "123456", otpCallback);
+        verify(authRepository).verifySignupOtp(eq("test@mail.com"), eq("123456"), eq(otpCallback));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void completeSignup_onSuccessWithToken_savesSessionAndCallsBack() {
+        ArgumentCaptor<RepositoryCallback<LoginResponse>> captor =
+                ArgumentCaptor.forClass(RepositoryCallback.class);
+
+        otpSignupUseCase.completeSignup("test@mail.com", "123456", "pass123", "John", "Doe", "12345678", loginCallback);
+        
+        verify(authRepository).completeSignupWithOtp(
+                eq("test@mail.com"), eq("123456"), eq("pass123"), eq("John"), eq("Doe"), eq("12345678"), captor.capture());
+
+        LoginResponse response = new LoginResponse();
+        response.token = "jwt-token";
+        response.userId = 1L;
+        response.email = "test@mail.com";
+        response.firstName = "John";
+        response.lastName = "Doe";
+        
+        captor.getValue().onSuccess(response);
+
+        verify(sessionRepository).saveSession(eq("jwt-token"), argThat(user ->
+                user.id == 1L && "test@mail.com".equals(user.email)
+        ));
+        verify(loginCallback).onSuccess(response);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void completeSignup_onError_forwardsError() {
+        ArgumentCaptor<RepositoryCallback<LoginResponse>> captor =
+                ArgumentCaptor.forClass(RepositoryCallback.class);
+
+        otpSignupUseCase.completeSignup("test@mail.com", "wrong", "pass", "J", "D", "1", loginCallback);
+        verify(authRepository).completeSignupWithOtp(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), captor.capture());
+
+        UiMessage errorMsg = UiMessage.from("Error");
+        captor.getValue().onError(errorMsg);
+
+        verify(loginCallback).onError(errorMsg);
+        verify(sessionRepository, never()).saveSession(anyString(), any());
+    }
+
+    @Test
+    public void cancel_cancelsRepositoryCalls() {
+        otpSignupUseCase.cancel();
+        verify(authRepository).cancelAll();
+    }
+}


### PR DESCRIPTION
## 🚀 Mejora en el manejo de errores de registro y validación CI

Esta Pull Request (PR) se enfoca en mejorar la experiencia de usuario durante el flujo de registro (OTP), asegurando que los errores de red y de servidor se comuniquen de manera clara y profesional. Además, se fortalece el ciclo de vida de desarrollo integrando pruebas unitarias automáticas en el pipeline de CI.

---

## 📋 Cambios realizados

### 🎨 UI/UX y Flujo de Usuario

- **Validación visual en campos**: Se modificó el `SignupFragment` para mostrar errores directamente en el `TextInputLayout` del email en lugar de Snackbars genéricos.  
- **Limpieza dinámica**: Se implementó un `TextWatcher` que elimina los mensajes de error automáticamente en cuanto el usuario comienza a escribir.  
- **Manejo de estados**: Se restringió la visualización de errores a una única vez por evento para evitar ruido en la interfaz.  

---

### 🛠️ Networking y Estabilidad

- **Mensajes amigables**: Se actualizaron los recursos de `strings.xml` para mostrar mensajes más claros (ej: _"En este momento no puede realizarse el envío de mail"_ en lugar de _"Internal Server Error"_).  
- **Seguridad de Red**: Se actualizó `network_security_config.xml` para permitir tráfico cleartext (HTTP) a IPs de desarrollo local (`10.100.41.96`, `192.168.1.33`, etc.).  
- **Parser de errores**: Se mejoró `NetworkErrorParser` para interceptar códigos de error 500 y fallos de conexión, mapeándolos a recursos de texto localizados y amigables.  

---

### 🧪 Calidad y CI/CD

- **Tests unitarios**: Se crearon pruebas para `OtpSignupUseCase` cubriendo:
  - Solicitud y reenvío de OTP  
  - Validación de código exitosa y fallida  
  - Persistencia de sesión al completar el registro  

- **GitHub Actions**: Se actualizó el workflow `android-ci.yml` para ejecutar automáticamente:

```bash
./gradlew :app:testDebugUnitTest

### Captura
<img width="505" height="1094" alt="image" src="https://github.com/user-attachments/assets/6d6fcb0f-fb0c-4558-9944-895b5f1aafdc" />
