### PR TITLE
Voucher + Modo sin conexión en Reservas

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,10 @@ android {
     }
 }
 
+kapt {
+    correctErrorTypes = true
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,14 @@ dependencies {
     implementation("androidx.room:room-runtime:$room_version")
     kapt("androidx.room:room-compiler:$room_version")
 
+    // WorkManager — sincronización en background
+    implementation("androidx.work:work-runtime:2.9.0")
+    implementation("androidx.hilt:hilt-work:1.2.0")
+    kapt("androidx.hilt:hilt-compiler:1.2.0")
+
+    // Pull-to-refresh
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:name=".XploreNowApplication"
@@ -32,6 +35,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Desactiva el inicializador automático de WorkManager para usar la config de Hilt -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup.InitializationProvider"
+                tools:node="remove" />
+        </provider>
 
     </application>
 

--- a/app/src/main/assets/config.json
+++ b/app/src/main/assets/config.json
@@ -18,5 +18,6 @@
   "profile_endpoint": "users/{userId}/profile",
   "preferences_endpoint": "users/preferences",
   "activity_summary_endpoint": "users/activities/summary",
-  "categories_endpoint": "categories"
+  "categories_endpoint": "categories",
+  "my_reviews_endpoint": "users/{userId}/reviews/mine"
 }

--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -4,10 +4,12 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.NavOptions;
 import androidx.navigation.fragment.NavHostFragment;
 import com.example.myapplication.data.session.SessionManager;
+import com.example.myapplication.ui.main.MainViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import dagger.hilt.android.AndroidEntryPoint;
 import javax.inject.Inject;
@@ -22,6 +24,8 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        new ViewModelProvider(this).get(MainViewModel.class);
 
         NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.nav_host_fragment);

--- a/app/src/main/java/com/example/myapplication/XploreNowApplication.java
+++ b/app/src/main/java/com/example/myapplication/XploreNowApplication.java
@@ -1,8 +1,23 @@
 package com.example.myapplication;
 
 import android.app.Application;
+import androidx.annotation.NonNull;
+import androidx.work.Configuration;
+import androidx.hilt.work.HiltWorkerFactory;
 import dagger.hilt.android.HiltAndroidApp;
+import javax.inject.Inject;
 
 @HiltAndroidApp
-public class XploreNowApplication extends Application {
+public class XploreNowApplication extends Application implements Configuration.Provider {
+
+    @Inject
+    HiltWorkerFactory workerFactory;
+
+    @NonNull
+    @Override
+    public Configuration getWorkManagerConfiguration() {
+        return new Configuration.Builder()
+                .setWorkerFactory(workerFactory)
+                .build();
+    }
 }

--- a/app/src/main/java/com/example/myapplication/data/local/AppDatabase.java
+++ b/app/src/main/java/com/example/myapplication/data/local/AppDatabase.java
@@ -2,8 +2,42 @@ package com.example.myapplication.data.local;
 
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {OfflineBookingEntity.class}, version = 4, exportSchema = false)
+@Database(
+    entities = {OfflineBookingEntity.class, CachedActivityEntity.class},
+    version = 5,
+    exportSchema = false
+)
 public abstract class AppDatabase extends RoomDatabase {
     public abstract OfflineBookingDao offlineBookingDao();
+    public abstract CachedActivityDao cachedActivityDao();
+
+    public static final Migration MIGRATION_4_5 = new Migration(4, 5) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS `cached_activities` (" +
+                "`id` INTEGER NOT NULL, " +
+                "`name` TEXT, " +
+                "`destinationName` TEXT, " +
+                "`category` TEXT, " +
+                "`description` TEXT, " +
+                "`imageUrl` TEXT, " +
+                "`durationMinutes` INTEGER NOT NULL DEFAULT 0, " +
+                "`basePrice` REAL NOT NULL DEFAULT 0, " +
+                "`currency` TEXT, " +
+                "`guideName` TEXT, " +
+                "`meetingPoint` TEXT, " +
+                "`language` TEXT, " +
+                "`includesText` TEXT, " +
+                "`cancellationPolicy` TEXT, " +
+                "`avgRating` REAL NOT NULL DEFAULT 0, " +
+                "`reviewCount` INTEGER NOT NULL DEFAULT 0, " +
+                "`availableSpots` INTEGER NOT NULL DEFAULT 0, " +
+                "PRIMARY KEY(`id`))"
+            );
+        }
+    };
 }

--- a/app/src/main/java/com/example/myapplication/data/local/AppDatabase.java
+++ b/app/src/main/java/com/example/myapplication/data/local/AppDatabase.java
@@ -3,7 +3,7 @@ package com.example.myapplication.data.local;
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
 
-@Database(entities = {OfflineBookingEntity.class}, version = 2, exportSchema = false)
+@Database(entities = {OfflineBookingEntity.class}, version = 4, exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase {
     public abstract OfflineBookingDao offlineBookingDao();
 }

--- a/app/src/main/java/com/example/myapplication/data/local/CachedActivityDao.java
+++ b/app/src/main/java/com/example/myapplication/data/local/CachedActivityDao.java
@@ -1,0 +1,26 @@
+package com.example.myapplication.data.local;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import java.util.List;
+
+@Dao
+public interface CachedActivityDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void upsertAll(List<CachedActivityEntity> activities);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void upsert(CachedActivityEntity activity);
+
+    @Query("SELECT * FROM cached_activities WHERE id = :id")
+    CachedActivityEntity getById(long id);
+
+    @Query("SELECT * FROM cached_activities")
+    List<CachedActivityEntity> getAll();
+
+    @Query("SELECT COUNT(*) FROM cached_activities")
+    int count();
+}

--- a/app/src/main/java/com/example/myapplication/data/local/CachedActivityEntity.java
+++ b/app/src/main/java/com/example/myapplication/data/local/CachedActivityEntity.java
@@ -1,0 +1,26 @@
+package com.example.myapplication.data.local;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "cached_activities")
+public class CachedActivityEntity {
+    @PrimaryKey
+    public long id;
+    public String name;
+    public String destinationName;
+    public String category;
+    public String description;
+    public String imageUrl;
+    public int durationMinutes;
+    public double basePrice;
+    public String currency;
+    public String guideName;
+    public String meetingPoint;
+    public String language;
+    public String includesText;
+    public String cancellationPolicy;
+    public float avgRating;
+    public int reviewCount;
+    public int availableSpots;
+}

--- a/app/src/main/java/com/example/myapplication/data/local/OfflineBookingDao.java
+++ b/app/src/main/java/com/example/myapplication/data/local/OfflineBookingDao.java
@@ -13,16 +13,19 @@ public interface OfflineBookingDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertAll(List<OfflineBookingEntity> bookings);
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    void insertAllIgnore(List<OfflineBookingEntity> bookings);
+
     @Query("SELECT * FROM offline_bookings WHERE userId = :userId AND status = 'CONFIRMED' ORDER BY sessionStartTime ASC")
     List<OfflineBookingEntity> getConfirmedByUser(long userId);
 
-    @Query("DELETE FROM offline_bookings WHERE userId = :userId AND status = 'CONFIRMED'")
+    @Query("DELETE FROM offline_bookings WHERE userId = :userId AND status = 'CONFIRMED' AND pendingCancel = 0")
     void deleteConfirmedByUser(long userId);
 
     @Transaction
     default void replaceConfirmed(long userId, List<OfflineBookingEntity> bookings) {
         deleteConfirmedByUser(userId);
-        if (!bookings.isEmpty()) insertAll(bookings);
+        if (!bookings.isEmpty()) insertAllIgnore(bookings);
     }
 
     @Query("UPDATE offline_bookings SET pendingCancel = 1, status = 'CANCELLED' WHERE id = :id")
@@ -33,4 +36,10 @@ public interface OfflineBookingDao {
 
     @Query("DELETE FROM offline_bookings WHERE id = :id")
     void deleteById(long id);
+
+    @Query("DELETE FROM offline_bookings WHERE userId = :userId")
+    void deleteAllByUser(long userId);
+
+    @Query("SELECT * FROM offline_bookings WHERE id = :id LIMIT 1")
+    OfflineBookingEntity getById(long id);
 }

--- a/app/src/main/java/com/example/myapplication/data/local/OfflineBookingDao.java
+++ b/app/src/main/java/com/example/myapplication/data/local/OfflineBookingDao.java
@@ -16,7 +16,7 @@ public interface OfflineBookingDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     void insertAllIgnore(List<OfflineBookingEntity> bookings);
 
-    @Query("SELECT * FROM offline_bookings WHERE userId = :userId AND status = 'CONFIRMED' ORDER BY sessionStartTime ASC")
+    @Query("SELECT * FROM offline_bookings WHERE userId = :userId AND (status = 'CONFIRMED' OR pendingCancel = 1) ORDER BY sessionStartTime ASC")
     List<OfflineBookingEntity> getConfirmedByUser(long userId);
 
     @Query("DELETE FROM offline_bookings WHERE userId = :userId AND status = 'CONFIRMED' AND pendingCancel = 0")
@@ -28,8 +28,11 @@ public interface OfflineBookingDao {
         if (!bookings.isEmpty()) insertAllIgnore(bookings);
     }
 
-    @Query("UPDATE offline_bookings SET pendingCancel = 1, status = 'CANCELLED' WHERE id = :id")
+    @Query("UPDATE offline_bookings SET pendingCancel = 1 WHERE id = :id")
     void markPendingCancel(long id);
+
+    @Query("UPDATE offline_bookings SET pendingCancel = 0 WHERE id = :id")
+    void clearPendingCancel(long id);
 
     @Query("SELECT * FROM offline_bookings WHERE userId = :userId AND pendingCancel = 1")
     List<OfflineBookingEntity> getPendingCancellations(long userId);
@@ -42,4 +45,16 @@ public interface OfflineBookingDao {
 
     @Query("SELECT * FROM offline_bookings WHERE id = :id LIMIT 1")
     OfflineBookingEntity getById(long id);
+
+    @Query("SELECT * FROM offline_bookings WHERE userId = :userId AND status IN ('COMPLETED', 'CANCELLED') AND pendingCancel = 0 ORDER BY sessionStartTime DESC")
+    List<OfflineBookingEntity> getHistorialByUser(long userId);
+
+    @Query("DELETE FROM offline_bookings WHERE userId = :userId AND status IN ('COMPLETED', 'CANCELLED') AND pendingCancel = 0")
+    void deleteHistorialByUser(long userId);
+
+    @Transaction
+    default void replaceHistorial(long userId, List<OfflineBookingEntity> bookings) {
+        deleteHistorialByUser(userId);
+        if (!bookings.isEmpty()) insertAll(bookings);
+    }
 }

--- a/app/src/main/java/com/example/myapplication/data/local/OfflineBookingEntity.java
+++ b/app/src/main/java/com/example/myapplication/data/local/OfflineBookingEntity.java
@@ -24,4 +24,6 @@ public class OfflineBookingEntity {
     public String cancelledAt;
     public boolean canReview;
     public boolean pendingCancel;
+    public String voucherCode;
+    public String meetingPoint;
 }

--- a/app/src/main/java/com/example/myapplication/data/model/BookingResponse.java
+++ b/app/src/main/java/com/example/myapplication/data/model/BookingResponse.java
@@ -50,5 +50,11 @@ public class BookingResponse {
 
     @Json(name = "canReview")
     public boolean canReview;
+
+    @Json(name = "voucherCode")
+    public String voucherCode;
+
+    @Json(name = "meetingPoint")
+    public String meetingPoint;
 }
 

--- a/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
@@ -124,7 +124,9 @@ public class BookingRepository extends BaseRepository {
                         e.guideName != null ? e.guideName : "",
                         e.durationMinutes,
                         null,
-                        FormatUtils.extractTime(e.sessionStartTime)));
+                        FormatUtils.extractTime(e.sessionStartTime),
+                        false,
+                        e.sessionStartTime));
             }
             MainThreadUtils.post(() -> callback.onSuccess(result));
         });

--- a/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
@@ -2,6 +2,7 @@ package com.example.myapplication.data.repository;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import com.example.myapplication.R;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.local.OfflineBookingDao;
@@ -15,13 +16,18 @@ import com.example.myapplication.util.NetworkErrorParser;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 
 public class BookingRepository extends BaseRepository {
 
+    private static final String TAG = "BookingRepository";
+
     private final BookingService bookingService;
     private final SessionRepository sessionRepository;
     private final OfflineBookingDao offlineBookingDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     @Inject
     public BookingRepository(BookingService bookingService, SessionRepository sessionRepository,
@@ -40,10 +46,13 @@ public class BookingRepository extends BaseRepository {
                     @Override
                     public void onSuccess(BookingResponse data) {
                         if (data != null) {
-                            new Thread(() -> offlineBookingDao.insertAll(
-                                    Collections.singletonList(toEntity(data, userId)))).start();
+                            dbExecutor.execute(() -> {
+                                offlineBookingDao.insertAll(Collections.singletonList(toEntity(data, userId)));
+                                new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(data));
+                            });
+                        } else {
+                            callback.onSuccess(null);
                         }
-                        callback.onSuccess(data);
                     }
 
                     @Override
@@ -67,9 +76,16 @@ public class BookingRepository extends BaseRepository {
                 if ("CONFIRMED".equals(statusFilter)) {
                     List<OfflineBookingEntity> entities = new ArrayList<>();
                     for (BookingResponse b : items) entities.add(toEntity(b, userId));
-                    new Thread(() -> offlineBookingDao.replaceConfirmed(userId, entities)).start();
+                    dbExecutor.execute(() -> {
+                        offlineBookingDao.replaceConfirmed(userId, entities);
+                        List<OfflineBookingEntity> roomData = offlineBookingDao.getConfirmedByUser(userId);
+                        List<BookingResponse> result = new ArrayList<>();
+                        for (OfflineBookingEntity e : roomData) result.add(fromEntity(e));
+                        new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+                    });
+                } else {
+                    callback.onSuccess(items);
                 }
-                callback.onSuccess(items);
             }
 
             @Override
@@ -81,40 +97,73 @@ public class BookingRepository extends BaseRepository {
 
     public void loadCachedConfirmedBookings(RepositoryCallback<List<BookingResponse>> callback) {
         long userId = sessionRepository.getUserId();
-        new Thread(() -> {
+        dbExecutor.execute(() -> {
             List<OfflineBookingEntity> entities = offlineBookingDao.getConfirmedByUser(userId);
             List<BookingResponse> result = new ArrayList<>();
             for (OfflineBookingEntity e : entities) result.add(fromEntity(e));
             new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
-        }).start();
+        });
     }
 
     public void cancelBooking(Long bookingId, RepositoryCallback<BookingResponse> callback) {
         long userId = sessionRepository.getUserId();
         String url = "users/" + userId + "/bookings/" + bookingId;
-        enqueue(bookingService.cancelBooking(url), callback, R.string.error_internal_server);
+        enqueue(bookingService.cancelBooking(url), new RepositoryCallback<BookingResponse>() {
+            @Override
+            public void onSuccess(BookingResponse data) {
+                if (bookingId != null) {
+                    dbExecutor.execute(() -> offlineBookingDao.deleteById(bookingId));
+                }
+                callback.onSuccess(data);
+            }
+
+            @Override
+            public void onError(com.example.myapplication.data.common.UiMessage error) {
+                callback.onError(error);
+            }
+        }, R.string.error_internal_server);
+    }
+
+    public void loadCachedPendingCancellations(RepositoryCallback<List<BookingResponse>> callback) {
+        long userId = sessionRepository.getUserId();
+        dbExecutor.execute(() -> {
+            List<OfflineBookingEntity> entities = offlineBookingDao.getPendingCancellations(userId);
+            List<BookingResponse> result = new ArrayList<>();
+            for (OfflineBookingEntity e : entities) {
+                BookingResponse b = fromEntity(e);
+                b.status = "PENDING_CANCEL";
+                result.add(b);
+            }
+            new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+        });
     }
 
     public void cancelBookingLocally(Long bookingId, Runnable onDone) {
-        new Thread(() -> {
+        dbExecutor.execute(() -> {
             if (bookingId != null) offlineBookingDao.markPendingCancel(bookingId);
             new Handler(Looper.getMainLooper()).post(onDone);
-        }).start();
+        });
     }
 
     public void syncPendingCancellations(Runnable onComplete) {
         long userId = sessionRepository.getUserId();
-        new Thread(() -> {
+        dbExecutor.execute(() -> {
             List<OfflineBookingEntity> pending = offlineBookingDao.getPendingCancellations(userId);
             for (OfflineBookingEntity e : pending) {
                 try {
                     retrofit2.Response<BookingResponse> resp =
                             bookingService.cancelBooking("users/" + userId + "/bookings/" + e.id).execute();
-                    if (resp.isSuccessful()) offlineBookingDao.deleteById(e.id);
-                } catch (Exception ignored) {}
+                    if (resp.isSuccessful()) {
+                        offlineBookingDao.deleteById(e.id);
+                    } else {
+                        Log.w(TAG, "Sync cancelación fallida para booking " + e.id + " — HTTP " + resp.code());
+                    }
+                } catch (Exception ex) {
+                    Log.e(TAG, "Error sincronizando cancelación pendiente para booking " + e.id, ex);
+                }
             }
             new Handler(Looper.getMainLooper()).post(onComplete);
-        }).start();
+        });
     }
 
     private static OfflineBookingEntity toEntity(BookingResponse b, long userId) {
@@ -136,6 +185,8 @@ public class BookingRepository extends BaseRepository {
         e.createdAt = b.createdAt;
         e.cancelledAt = b.cancelledAt;
         e.canReview = b.canReview;
+        e.voucherCode = b.voucherCode;
+        e.meetingPoint = b.meetingPoint;
         return e;
     }
 
@@ -160,6 +211,8 @@ public class BookingRepository extends BaseRepository {
         b.createdAt = e.createdAt;
         b.cancelledAt = e.cancelledAt;
         b.canReview = e.canReview;
+        b.voucherCode = e.voucherCode;
+        b.meetingPoint = e.meetingPoint;
         return b;
     }
 }

--- a/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
@@ -9,8 +9,10 @@ import com.example.myapplication.data.local.OfflineBookingDao;
 import com.example.myapplication.data.local.OfflineBookingEntity;
 import com.example.myapplication.data.model.BookingResponse;
 import com.example.myapplication.data.model.BookingsPageResponse;
+import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.model.CreateBookingRequest;
 import com.example.myapplication.data.model.DestinationResponse;
+import com.example.myapplication.util.FormatUtils;
 import com.example.myapplication.data.network.BookingService;
 import com.example.myapplication.util.NetworkErrorParser;
 import java.util.ArrayList;
@@ -101,6 +103,30 @@ public class BookingRepository extends BaseRepository {
             List<OfflineBookingEntity> entities = offlineBookingDao.getConfirmedByUser(userId);
             List<BookingResponse> result = new ArrayList<>();
             for (OfflineBookingEntity e : entities) result.add(fromEntity(e));
+            new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+        });
+    }
+
+    public void loadCachedHistorial(RepositoryCallback<List<BookingSummaryItem>> callback) {
+        long userId = sessionRepository.getUserId();
+        dbExecutor.execute(() -> {
+            List<OfflineBookingEntity> entities = offlineBookingDao.getHistorialByUser(userId);
+            List<BookingSummaryItem> result = new ArrayList<>(entities.size());
+            for (OfflineBookingEntity e : entities) {
+                String date = FormatUtils.formatDate(e.sessionStartTime);
+                String time = "";
+                if (e.sessionStartTime != null) {
+                    String formatted = FormatUtils.formatStartTime(e.sessionStartTime);
+                    if (formatted.length() >= 16) time = formatted.substring(11, 16);
+                }
+                String price = FormatUtils.formatPrice(e.totalPrice, e.currency);
+                result.add(new BookingSummaryItem(
+                        e.id > 0 ? e.id : null, e.activityId, e.activityName, e.status,
+                        date, price,
+                        e.destinationName != null ? e.destinationName : "",
+                        e.guideName != null ? e.guideName : "",
+                        e.durationMinutes, null, time));
+            }
             new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
         });
     }
@@ -206,7 +232,7 @@ public class BookingRepository extends BaseRepository {
         b.participants = e.participants;
         b.totalPrice = e.totalPrice;
         b.currency = e.currency;
-        b.status = e.status;
+        b.status = e.pendingCancel ? "PENDING_CANCEL" : e.status;
         b.cancellationPolicy = e.cancellationPolicy;
         b.createdAt = e.createdAt;
         b.cancelledAt = e.cancelledAt;

--- a/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/BookingRepository.java
@@ -1,10 +1,9 @@
 package com.example.myapplication.data.repository;
 
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import com.example.myapplication.R;
 import com.example.myapplication.data.common.RepositoryCallback;
+import com.example.myapplication.data.common.UiMessage;
 import com.example.myapplication.data.local.OfflineBookingDao;
 import com.example.myapplication.data.local.OfflineBookingEntity;
 import com.example.myapplication.data.model.BookingResponse;
@@ -13,6 +12,7 @@ import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.model.CreateBookingRequest;
 import com.example.myapplication.data.model.DestinationResponse;
 import com.example.myapplication.util.FormatUtils;
+import com.example.myapplication.util.MainThreadUtils;
 import com.example.myapplication.data.network.BookingService;
 import com.example.myapplication.util.NetworkErrorParser;
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public class BookingRepository extends BaseRepository {
                         if (data != null) {
                             dbExecutor.execute(() -> {
                                 offlineBookingDao.insertAll(Collections.singletonList(toEntity(data, userId)));
-                                new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(data));
+                                MainThreadUtils.post(() -> callback.onSuccess(data));
                             });
                         } else {
                             callback.onSuccess(null);
@@ -58,7 +58,7 @@ public class BookingRepository extends BaseRepository {
                     }
 
                     @Override
-                    public void onError(com.example.myapplication.data.common.UiMessage error) {
+                    public void onError(UiMessage error) {
                         callback.onError(error);
                     }
                 }, R.string.error_internal_server);
@@ -83,7 +83,7 @@ public class BookingRepository extends BaseRepository {
                         List<OfflineBookingEntity> roomData = offlineBookingDao.getConfirmedByUser(userId);
                         List<BookingResponse> result = new ArrayList<>();
                         for (OfflineBookingEntity e : roomData) result.add(fromEntity(e));
-                        new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+                        MainThreadUtils.post(() -> callback.onSuccess(result));
                     });
                 } else {
                     callback.onSuccess(items);
@@ -91,7 +91,7 @@ public class BookingRepository extends BaseRepository {
             }
 
             @Override
-            public void onError(com.example.myapplication.data.common.UiMessage error) {
+            public void onError(UiMessage error) {
                 callback.onError(error);
             }
         }, R.string.error_internal_server);
@@ -103,7 +103,7 @@ public class BookingRepository extends BaseRepository {
             List<OfflineBookingEntity> entities = offlineBookingDao.getConfirmedByUser(userId);
             List<BookingResponse> result = new ArrayList<>();
             for (OfflineBookingEntity e : entities) result.add(fromEntity(e));
-            new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+            MainThreadUtils.post(() -> callback.onSuccess(result));
         });
     }
 
@@ -113,21 +113,20 @@ public class BookingRepository extends BaseRepository {
             List<OfflineBookingEntity> entities = offlineBookingDao.getHistorialByUser(userId);
             List<BookingSummaryItem> result = new ArrayList<>(entities.size());
             for (OfflineBookingEntity e : entities) {
-                String date = FormatUtils.formatDate(e.sessionStartTime);
-                String time = "";
-                if (e.sessionStartTime != null) {
-                    String formatted = FormatUtils.formatStartTime(e.sessionStartTime);
-                    if (formatted.length() >= 16) time = formatted.substring(11, 16);
-                }
-                String price = FormatUtils.formatPrice(e.totalPrice, e.currency);
                 result.add(new BookingSummaryItem(
-                        e.id > 0 ? e.id : null, e.activityId, e.activityName, e.status,
-                        date, price,
+                        e.id > 0 ? e.id : null,
+                        e.activityId,
+                        e.activityName,
+                        e.status,
+                        FormatUtils.formatDate(e.sessionStartTime),
+                        FormatUtils.formatPrice(e.totalPrice, e.currency),
                         e.destinationName != null ? e.destinationName : "",
                         e.guideName != null ? e.guideName : "",
-                        e.durationMinutes, null, time));
+                        e.durationMinutes,
+                        null,
+                        FormatUtils.extractTime(e.sessionStartTime)));
             }
-            new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+            MainThreadUtils.post(() -> callback.onSuccess(result));
         });
     }
 
@@ -144,7 +143,7 @@ public class BookingRepository extends BaseRepository {
             }
 
             @Override
-            public void onError(com.example.myapplication.data.common.UiMessage error) {
+            public void onError(UiMessage error) {
                 callback.onError(error);
             }
         }, R.string.error_internal_server);
@@ -155,19 +154,15 @@ public class BookingRepository extends BaseRepository {
         dbExecutor.execute(() -> {
             List<OfflineBookingEntity> entities = offlineBookingDao.getPendingCancellations(userId);
             List<BookingResponse> result = new ArrayList<>();
-            for (OfflineBookingEntity e : entities) {
-                BookingResponse b = fromEntity(e);
-                b.status = "PENDING_CANCEL";
-                result.add(b);
-            }
-            new Handler(Looper.getMainLooper()).post(() -> callback.onSuccess(result));
+            for (OfflineBookingEntity e : entities) result.add(fromEntity(e));
+            MainThreadUtils.post(() -> callback.onSuccess(result));
         });
     }
 
     public void cancelBookingLocally(Long bookingId, Runnable onDone) {
         dbExecutor.execute(() -> {
             if (bookingId != null) offlineBookingDao.markPendingCancel(bookingId);
-            new Handler(Looper.getMainLooper()).post(onDone);
+            MainThreadUtils.post(onDone);
         });
     }
 
@@ -188,7 +183,7 @@ public class BookingRepository extends BaseRepository {
                     Log.e(TAG, "Error sincronizando cancelación pendiente para booking " + e.id, ex);
                 }
             }
-            new Handler(Looper.getMainLooper()).post(onComplete);
+            MainThreadUtils.post(onComplete);
         });
     }
 

--- a/app/src/main/java/com/example/myapplication/data/repository/ExploreRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/ExploreRepository.java
@@ -5,6 +5,7 @@ import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
 import com.example.myapplication.data.config.AppConfig;
 import com.example.myapplication.data.config.ConfigLoader;
+import com.example.myapplication.data.local.CachedActivityDao;
 import com.example.myapplication.data.model.ActivitiesPageResponse;
 import com.example.myapplication.data.model.ActivitySummaryResponse;
 import com.example.myapplication.data.model.DestinationResponse;
@@ -17,6 +18,8 @@ import com.example.myapplication.util.NetworkErrorParser;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import okhttp3.HttpUrl;
@@ -32,16 +35,19 @@ public class ExploreRepository extends BaseRepository {
     private final CatalogMetaService metaService;
     private final ConfigLoader configLoader;
     private final SessionManager sessionManager;
+    private final CachedActivityDao cachedActivityDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     @Inject
     public ExploreRepository(ActivityService activityService, CatalogMetaService metaService,
                              ConfigLoader configLoader, SessionManager sessionManager,
-                             NetworkErrorParser errorParser) {
+                             NetworkErrorParser errorParser, CachedActivityDao cachedActivityDao) {
         super(errorParser);
         this.activityService = activityService;
         this.metaService = metaService;
         this.configLoader = configLoader;
         this.sessionManager = sessionManager;
+        this.cachedActivityDao = cachedActivityDao;
     }
 
     public void listActivities(
@@ -66,7 +72,28 @@ public class ExploreRepository extends BaseRepository {
             return;
         }
 
-        enqueue(activityService.listActivities(url.toString()), callback, R.string.error_load_activities);
+        enqueue(activityService.listActivities(url.toString()),
+                new RepositoryCallback<ActivitiesPageResponse>() {
+                    @Override
+                    public void onSuccess(ActivitiesPageResponse data) {
+                        if (data.items != null && !data.items.isEmpty()) {
+                            dbExecutor.execute(() -> {
+                                List<com.example.myapplication.data.local.CachedActivityEntity> entities =
+                                        new ArrayList<>(data.items.size());
+                                for (ActivitySummaryResponse item : data.items) {
+                                    if (item.id != null) entities.add(TourRepository.fromSummary(item));
+                                }
+                                if (!entities.isEmpty()) cachedActivityDao.upsertAll(entities);
+                            });
+                        }
+                        callback.onSuccess(data);
+                    }
+                    @Override
+                    public void onError(UiMessage error) {
+                        callback.onError(error);
+                    }
+                },
+                R.string.error_load_activities);
     }
 
     public void listDestinations(RepositoryCallback<List<DestinationResponse>> callback) {

--- a/app/src/main/java/com/example/myapplication/data/repository/ProfileRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/ProfileRepository.java
@@ -5,6 +5,8 @@ import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
 import com.example.myapplication.data.config.AppConfig;
 import com.example.myapplication.data.config.ConfigLoader;
+import com.example.myapplication.data.local.OfflineBookingDao;
+import com.example.myapplication.data.local.OfflineBookingEntity;
 import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.model.BookingSummaryItemResponse;
 import com.example.myapplication.data.model.BookingSummaryPageResponse;
@@ -18,6 +20,8 @@ import com.example.myapplication.util.NetworkErrorParser;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import okhttp3.MediaType;
@@ -31,15 +35,19 @@ public class ProfileRepository extends BaseRepository {
     private final ProfileService profileService;
     private final ConfigLoader configLoader;
     private final com.example.myapplication.data.session.SessionManager sessionManager;
+    private final OfflineBookingDao offlineBookingDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     @Inject
     public ProfileRepository(ProfileService profileService, ConfigLoader configLoader,
                              NetworkErrorParser errorParser,
-                             com.example.myapplication.data.session.SessionManager sessionManager) {
+                             com.example.myapplication.data.session.SessionManager sessionManager,
+                             OfflineBookingDao offlineBookingDao) {
         super(errorParser);
         this.profileService = profileService;
         this.configLoader = configLoader;
         this.sessionManager = sessionManager;
+        this.offlineBookingDao = offlineBookingDao;
     }
 
     public void getProfile(RepositoryCallback<UserProfileData> callback) {
@@ -142,7 +150,9 @@ public class ProfileRepository extends BaseRepository {
                 activeCalls.remove(c);
                 if (response.isSuccessful() && response.body() != null
                         && response.body().items != null) {
-                    callback.onSuccess(mapToSummaryItems(response.body().items));
+                    List<BookingSummaryItemResponse> rawItems = response.body().items;
+                    persistHistorial(rawItems);
+                    callback.onSuccess(mapToSummaryItems(rawItems));
                 } else {
                     callback.onError(errorParser.getErrorMessage(response, R.string.error_load_profile));
                 }
@@ -221,6 +231,27 @@ public class ProfileRepository extends BaseRepository {
             r.completedBookings,
             r.cancelledBookings
         );
+    }
+
+    private void persistHistorial(List<BookingSummaryItemResponse> items) {
+        long userId = sessionManager.getUserId();
+        List<OfflineBookingEntity> entities = new ArrayList<>(items.size());
+        for (BookingSummaryItemResponse item : items) {
+            OfflineBookingEntity e = new OfflineBookingEntity();
+            e.id = item.id != null ? item.id : 0;
+            e.userId = userId;
+            e.activityId = item.activityId;
+            e.activityName = item.activityName;
+            e.status = item.status;
+            e.destinationName = item.destination;
+            e.guideName = item.guideName;
+            e.sessionStartTime = item.sessionStartTime;
+            e.durationMinutes = item.durationMinutes;
+            e.totalPrice = item.totalPrice;
+            e.currency = item.currency;
+            entities.add(e);
+        }
+        dbExecutor.execute(() -> offlineBookingDao.replaceHistorial(userId, entities));
     }
 
     private List<BookingSummaryItem> mapToSummaryItems(List<BookingSummaryItemResponse> items) {

--- a/app/src/main/java/com/example/myapplication/data/repository/TourRepository.java
+++ b/app/src/main/java/com/example/myapplication/data/repository/TourRepository.java
@@ -5,14 +5,20 @@ import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
 import com.example.myapplication.data.config.AppConfig;
 import com.example.myapplication.data.config.ConfigLoader;
+import com.example.myapplication.data.local.CachedActivityDao;
+import com.example.myapplication.data.local.CachedActivityEntity;
 import com.example.myapplication.data.model.ActivitiesPageResponse;
 import com.example.myapplication.data.model.ActivityDetailResponse;
 import com.example.myapplication.data.model.ActivitySummaryResponse;
 import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.data.network.ActivityService;
+import com.example.myapplication.util.FormatUtils;
 import com.example.myapplication.util.NetworkErrorParser;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import retrofit2.Call;
@@ -23,13 +29,16 @@ public class TourRepository extends BaseRepository {
 
     private final ActivityService activityService;
     private final ConfigLoader configLoader;
+    private final CachedActivityDao cachedActivityDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     @Inject
     public TourRepository(ActivityService activityService, ConfigLoader configLoader,
-                          NetworkErrorParser errorParser) {
+                          NetworkErrorParser errorParser, CachedActivityDao cachedActivityDao) {
         super(errorParser);
         this.activityService = activityService;
         this.configLoader = configLoader;
+        this.cachedActivityDao = cachedActivityDao;
     }
 
     public void getFeaturedTours(RepositoryCallback<List<TourActivity>> callback) {
@@ -99,6 +108,32 @@ public class TourRepository extends BaseRepository {
         enqueue(activityService.getCategories(config.categoriesEndpoint), callback, R.string.error_load_activities);
     }
 
+    public void getCachedActivity(long activityId, RepositoryCallback<TourActivity> callback) {
+        dbExecutor.execute(() -> {
+            CachedActivityEntity entity = cachedActivityDao.getById(activityId);
+            if (entity != null) {
+                callback.onSuccess(mapFromCache(entity));
+            } else {
+                callback.onError(UiMessage.from(R.string.error_load_activities));
+            }
+        });
+    }
+
+    public void getCachedActivities(RepositoryCallback<List<TourActivity>> callback) {
+        dbExecutor.execute(() -> {
+            List<CachedActivityEntity> entities = cachedActivityDao.getAll();
+            if (entities != null && !entities.isEmpty()) {
+                List<TourActivity> result = new ArrayList<>(entities.size());
+                for (CachedActivityEntity e : entities) result.add(mapFromCache(e));
+                callback.onSuccess(result);
+            } else {
+                callback.onError(UiMessage.from(R.string.error_load_activities));
+            }
+        });
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
     private void enqueuePage(Call<ActivitiesPageResponse> call,
                              RepositoryCallback<List<TourActivity>> callback,
                              int fallbackErrorResId) {
@@ -108,7 +143,9 @@ public class TourRepository extends BaseRepository {
             public void onResponse(Call<ActivitiesPageResponse> c, Response<ActivitiesPageResponse> response) {
                 activeCalls.remove(c);
                 if (response.isSuccessful() && response.body() != null && response.body().items != null) {
-                    callback.onSuccess(ExploreRepository.mapToTourActivities(response.body().items));
+                    List<ActivitySummaryResponse> items = response.body().items;
+                    cacheActivitiesAsync(items);
+                    callback.onSuccess(ExploreRepository.mapToTourActivities(items));
                 } else {
                     callback.onError(errorParser.getErrorMessage(response, fallbackErrorResId));
                 }
@@ -131,7 +168,9 @@ public class TourRepository extends BaseRepository {
             public void onResponse(Call<ActivityDetailResponse> c, Response<ActivityDetailResponse> response) {
                 activeCalls.remove(c);
                 if (response.isSuccessful() && response.body() != null) {
-                    callback.onSuccess(response.body());
+                    ActivityDetailResponse data = response.body();
+                    cacheDetailAsync(data);
+                    callback.onSuccess(data);
                 } else {
                     callback.onError(errorParser.getErrorMessage(response, fallbackErrorResId));
                 }
@@ -145,10 +184,92 @@ public class TourRepository extends BaseRepository {
         });
     }
 
+    private void cacheActivitiesAsync(List<ActivitySummaryResponse> items) {
+        if (items == null || items.isEmpty()) return;
+        dbExecutor.execute(() -> {
+            List<CachedActivityEntity> entities = new ArrayList<>(items.size());
+            for (ActivitySummaryResponse item : items) {
+                if (item.id != null) entities.add(fromSummary(item));
+            }
+            if (!entities.isEmpty()) cachedActivityDao.upsertAll(entities);
+        });
+    }
+
+    private void cacheDetailAsync(ActivityDetailResponse data) {
+        if (data == null || data.id == null) return;
+        dbExecutor.execute(() -> cachedActivityDao.upsert(fromDetail(data)));
+    }
+
+    // ── Conversions ──────────────────────────────────────────────────────────
+
+    static CachedActivityEntity fromSummary(ActivitySummaryResponse s) {
+        CachedActivityEntity e = new CachedActivityEntity();
+        e.id = s.id;
+        e.name = s.name;
+        e.destinationName = s.destination != null ? s.destination.name : null;
+        e.category = s.category;
+        e.imageUrl = s.imageUrl;
+        e.durationMinutes = s.durationMinutes;
+        e.basePrice = s.price;
+        e.currency = s.currency;
+        e.availableSpots = s.availableSpots;
+        e.avgRating = s.avgRating != null ? s.avgRating.floatValue() : 0f;
+        e.reviewCount = s.reviewCount != null ? s.reviewCount.intValue() : 0;
+        return e;
+    }
+
+    static CachedActivityEntity fromDetail(ActivityDetailResponse d) {
+        CachedActivityEntity e = new CachedActivityEntity();
+        e.id = d.id;
+        e.name = d.name;
+        e.destinationName = d.destination != null ? d.destination.name : null;
+        e.category = d.category;
+        e.imageUrl = d.imageUrl;
+        e.durationMinutes = d.durationMinutes;
+        e.basePrice = d.basePrice;
+        e.currency = d.currency;
+        e.availableSpots = d.availableSpots;
+        e.avgRating = d.avgRating != null ? d.avgRating.floatValue() : 0f;
+        e.reviewCount = d.reviewCount != null ? d.reviewCount.intValue() : 0;
+        e.description = d.description;
+        e.guideName = d.guide != null ? d.guide.fullName : null;
+        e.meetingPoint = d.meetingPoint;
+        e.language = d.language;
+        e.includesText = d.includesText;
+        e.cancellationPolicy = d.cancellationPolicy;
+        return e;
+    }
+
+    public static TourActivity mapFromCache(CachedActivityEntity e) {
+        String category = e.category != null ? e.category.replace("_", " ") : "";
+        String duration = FormatUtils.formatDuration(e.durationMinutes);
+        String price = FormatUtils.formatPrice(e.basePrice, e.currency);
+        TourActivity a = new TourActivity(
+                e.name != null ? e.name : "",
+                e.destinationName != null ? e.destinationName : "",
+                category,
+                duration,
+                price,
+                e.availableSpots,
+                e.imageUrl,
+                e.description != null ? e.description : "",
+                e.avgRating,
+                e.reviewCount,
+                e.includesText != null ? e.includesText : "",
+                e.meetingPoint != null ? e.meetingPoint : "",
+                e.guideName != null ? e.guideName : "",
+                e.language != null ? e.language : "",
+                e.cancellationPolicy != null ? e.cancellationPolicy : "",
+                null
+        );
+        a.setId(e.id);
+        return a;
+    }
+
     private <T> AppConfig getConfig(RepositoryCallback<T> callback) {
         AppConfig config = configLoader.loadConfig();
         if (config == null || !config.hasValidBaseUrl()) {
-            callback.onError(UiMessage.from(R.string.error_invalid_config));
+            if (callback != null) callback.onError(UiMessage.from(R.string.error_invalid_config));
             return null;
         }
         return config;

--- a/app/src/main/java/com/example/myapplication/data/work/SyncCancellationsWorker.java
+++ b/app/src/main/java/com/example/myapplication/data/work/SyncCancellationsWorker.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.hilt.work.HiltWorker;
+import androidx.work.Data;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import com.example.myapplication.data.local.OfflineBookingDao;
@@ -43,7 +44,8 @@ public class SyncCancellationsWorker extends Worker {
         long userId = sessionRepository.getUserId();
         List<OfflineBookingEntity> pending = offlineBookingDao.getPendingCancellations(userId);
 
-        boolean anyFailed = false;
+        boolean anyRetryable = false;
+        int rejectedCount = 0;
         for (OfflineBookingEntity e : pending) {
             try {
                 retrofit2.Response<BookingResponse> resp =
@@ -52,19 +54,21 @@ public class SyncCancellationsWorker extends Worker {
                     offlineBookingDao.deleteById(e.id);
                     Log.d(TAG, "Cancelación sincronizada: booking " + e.id);
                 } else if (resp.code() >= 400 && resp.code() < 500) {
-                    // 4xx: el servidor rechazó la acción (ya cancelada o no encontrada) → estado terminal, eliminar de Room
-                    offlineBookingDao.deleteById(e.id);
-                    Log.w(TAG, "Cancelación ya procesada en servidor (HTTP " + resp.code() + "), booking " + e.id + " removido del caché");
+                    // 4xx: el servidor rechazó la cancelación → restaurar a CONFIRMED y reportar al usuario
+                    offlineBookingDao.clearPendingCancel(e.id);
+                    rejectedCount++;
+                    Log.w(TAG, "Cancelación rechazada por el servidor (HTTP " + resp.code() + "), booking " + e.id + " restaurado a CONFIRMED");
                 } else {
                     Log.w(TAG, "Sync fallida para booking " + e.id + " — HTTP " + resp.code());
-                    anyFailed = true;
+                    anyRetryable = true;
                 }
             } catch (Exception ex) {
                 Log.e(TAG, "Error sincronizando booking " + e.id, ex);
-                anyFailed = true;
+                anyRetryable = true;
             }
         }
 
-        return anyFailed ? Result.retry() : Result.success();
+        Data output = new Data.Builder().putInt("failed_count", rejectedCount).build();
+        return anyRetryable ? Result.retry() : Result.success(output);
     }
 }

--- a/app/src/main/java/com/example/myapplication/data/work/SyncCancellationsWorker.java
+++ b/app/src/main/java/com/example/myapplication/data/work/SyncCancellationsWorker.java
@@ -1,0 +1,70 @@
+package com.example.myapplication.data.work;
+
+import android.content.Context;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.hilt.work.HiltWorker;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+import com.example.myapplication.data.local.OfflineBookingDao;
+import com.example.myapplication.data.local.OfflineBookingEntity;
+import com.example.myapplication.data.model.BookingResponse;
+import com.example.myapplication.data.network.BookingService;
+import com.example.myapplication.data.repository.SessionRepository;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
+import java.util.List;
+
+@HiltWorker
+public class SyncCancellationsWorker extends Worker {
+
+    private static final String TAG = "SyncCancellationsWorker";
+
+    private final BookingService bookingService;
+    private final OfflineBookingDao offlineBookingDao;
+    private final SessionRepository sessionRepository;
+
+    @AssistedInject
+    public SyncCancellationsWorker(
+            @Assisted Context context,
+            @Assisted WorkerParameters params,
+            BookingService bookingService,
+            OfflineBookingDao offlineBookingDao,
+            SessionRepository sessionRepository) {
+        super(context, params);
+        this.bookingService = bookingService;
+        this.offlineBookingDao = offlineBookingDao;
+        this.sessionRepository = sessionRepository;
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        long userId = sessionRepository.getUserId();
+        List<OfflineBookingEntity> pending = offlineBookingDao.getPendingCancellations(userId);
+
+        boolean anyFailed = false;
+        for (OfflineBookingEntity e : pending) {
+            try {
+                retrofit2.Response<BookingResponse> resp =
+                        bookingService.cancelBooking("users/" + userId + "/bookings/" + e.id).execute();
+                if (resp.isSuccessful()) {
+                    offlineBookingDao.deleteById(e.id);
+                    Log.d(TAG, "Cancelación sincronizada: booking " + e.id);
+                } else if (resp.code() >= 400 && resp.code() < 500) {
+                    // 4xx: el servidor rechazó la acción (ya cancelada o no encontrada) → estado terminal, eliminar de Room
+                    offlineBookingDao.deleteById(e.id);
+                    Log.w(TAG, "Cancelación ya procesada en servidor (HTTP " + resp.code() + "), booking " + e.id + " removido del caché");
+                } else {
+                    Log.w(TAG, "Sync fallida para booking " + e.id + " — HTTP " + resp.code());
+                    anyFailed = true;
+                }
+            } catch (Exception ex) {
+                Log.e(TAG, "Error sincronizando booking " + e.id, ex);
+                anyFailed = true;
+            }
+        }
+
+        return anyFailed ? Result.retry() : Result.success();
+    }
+}

--- a/app/src/main/java/com/example/myapplication/di/AppModule.java
+++ b/app/src/main/java/com/example/myapplication/di/AppModule.java
@@ -7,6 +7,7 @@ import com.example.myapplication.BuildConfig;
 import com.example.myapplication.data.config.AppConfig;
 import com.example.myapplication.data.config.ConfigLoader;
 import com.example.myapplication.data.local.AppDatabase;
+import com.example.myapplication.data.local.CachedActivityDao;
 import com.example.myapplication.data.local.OfflineBookingDao;
 import com.example.myapplication.data.network.ActivityService;
 import com.example.myapplication.data.network.AuthService;
@@ -225,6 +226,7 @@ public class AppModule {
     @Singleton
     static AppDatabase provideDatabase(@ApplicationContext Context context) {
         return Room.databaseBuilder(context, AppDatabase.class, "xplorenow_db")
+                .addMigrations(AppDatabase.MIGRATION_4_5)
                 .fallbackToDestructiveMigration()
                 .build();
     }
@@ -233,5 +235,11 @@ public class AppModule {
     @Singleton
     static OfflineBookingDao provideOfflineBookingDao(AppDatabase db) {
         return db.offlineBookingDao();
+    }
+
+    @Provides
+    @Singleton
+    static CachedActivityDao provideCachedActivityDao(AppDatabase db) {
+        return db.cachedActivityDao();
     }
 }

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -174,14 +174,16 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         holder.detailButton.setOnClickListener(v -> {
             if (detailClickListener != null) detailClickListener.onDetail(booking);
         });
-        /**
-         * Configura visibilidad, habilitación y alpha de un botón de forma DRY.
-         */
-        private void setButtonState(View button, boolean visible, boolean enabled, float alpha) {
-            button.setVisibility(visible ? View.VISIBLE : View.GONE);
-            button.setEnabled(enabled);
-            button.setAlpha(alpha);
-        }
+    }
+
+    /**
+     * Configura visibilidad, habilitación y alpha de un botón de forma DRY.
+     */
+    private void setButtonState(View button, boolean visible, boolean enabled, float alpha) {
+        button.setVisibility(visible ? View.VISIBLE : View.GONE);
+        button.setEnabled(enabled);
+        button.setAlpha(alpha);
+    }
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -5,6 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
@@ -37,9 +38,15 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         void onDetail(BookingResponse booking);
     }
 
+    public interface OnVoucherClickListener {
+        void onVoucher(BookingResponse booking);
+    }
+
     private List<BookingListItem> items = Collections.emptyList();
+    private boolean offline = false;
     private final OnCancelClickListener cancelClickListener;
     private OnDetailClickListener detailClickListener;
+    private OnVoucherClickListener voucherClickListener;
     private final OnReviewClickListener reviewClickListener;
 
     public BookingAdapter(OnCancelClickListener cancelClickListener, OnReviewClickListener reviewClickListener) {
@@ -51,9 +58,20 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         this.detailClickListener = listener;
     }
 
+    public void setOnVoucherClickListener(OnVoucherClickListener listener) {
+        this.voucherClickListener = listener;
+    }
+
     public void updateData(List<BookingListItem> newItems) {
         items = newItems != null ? newItems : Collections.emptyList();
         notifyDataSetChanged();
+    }
+
+    public void setOffline(boolean offline) {
+        if (this.offline != offline) {
+            this.offline = offline;
+            notifyDataSetChanged();
+        }
     }
 
     @Override
@@ -97,12 +115,7 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         holder.day.setText(item.dayNumber);
         holder.month.setText(item.monthAbbr);
 
-        if (!item.isToday) {
-            holder.statusBadge.setVisibility(View.VISIBLE);
-            holder.statusBadge.setText(R.string.booking_badge_upcoming);
-        } else {
-            holder.statusBadge.setVisibility(View.GONE);
-        }
+        bindStatusBadge(holder.statusBadge, booking.status);
 
         holder.title.setText(booking.activityName != null ? booking.activityName : "");
 
@@ -130,18 +143,71 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 && "COMPLETED".equalsIgnoreCase(booking.status)
                 && isWithinReviewWindow(booking.sessionStartTime, booking.durationMinutes);
         holder.reviewButton.setVisibility(canReview ? View.VISIBLE : View.GONE);
+        holder.reviewButton.setAlpha(offline ? 0.45f : 1f);
         holder.reviewButton.setOnClickListener(v -> {
-            if (reviewClickListener != null) reviewClickListener.onReview(booking);
+            if (offline) {
+                Toast.makeText(v.getContext(), R.string.review_offline_error, Toast.LENGTH_SHORT).show();
+            } else if (reviewClickListener != null) {
+                reviewClickListener.onReview(booking);
+            }
         });
 
         holder.detailButton.setOnClickListener(v -> {
             if (detailClickListener != null) detailClickListener.onDetail(booking);
+        });
+
+        boolean canVoucher = "CONFIRMED".equalsIgnoreCase(booking.status);
+        holder.voucherButton.setVisibility(canVoucher ? View.VISIBLE : View.GONE);
+        holder.voucherButton.setOnClickListener(v -> {
+            if (voucherClickListener != null) voucherClickListener.onVoucher(booking);
         });
     }
 
     @Override
     public int getItemCount() {
         return items.size();
+    }
+
+    private static void bindStatusBadge(TextView badge, String status) {
+        if (status == null) {
+            badge.setVisibility(View.GONE);
+            return;
+        }
+        android.content.Context ctx = badge.getContext();
+        String label;
+        int bgColor;
+        int textColor;
+        switch (status.toUpperCase()) {
+            case "CONFIRMED":
+                label = ctx.getString(R.string.status_confirmed);
+                bgColor = 0xFFE3F2FD;
+                textColor = 0xFF1565C0;
+                break;
+            case "COMPLETED":
+                label = ctx.getString(R.string.status_completed);
+                bgColor = 0xFFE8F5E9;
+                textColor = 0xFF2E7D32;
+                break;
+            case "CANCELLED":
+                label = ctx.getString(R.string.status_cancelled);
+                bgColor = 0xFFFFEBEE;
+                textColor = 0xFFB71C1C;
+                break;
+            case "PENDING":
+                label = ctx.getString(R.string.status_pending);
+                bgColor = 0xFFFFF8E1;
+                textColor = 0xFFE65100;
+                break;
+            default:
+                label = status;
+                bgColor = 0xFFF5F5F5;
+                textColor = 0xFF616161;
+                break;
+        }
+        badge.setText(label);
+        badge.setBackgroundTintList(android.content.res.ColorStateList.valueOf(bgColor));
+        badge.setTextColor(textColor);
+        badge.setVisibility(View.VISIBLE);
     }
 
     private static boolean isWithinReviewWindow(String sessionStartIso, int durationMinutes) {
@@ -191,20 +257,22 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         final MaterialButton detailButton;
         final MaterialButton cancelButton;
         final MaterialButton reviewButton;
+        final MaterialButton voucherButton;
 
         BookingViewHolder(@NonNull View itemView) {
             super(itemView);
-            day          = itemView.findViewById(R.id.booking_day);
-            month        = itemView.findViewById(R.id.booking_month);
-            statusBadge  = itemView.findViewById(R.id.booking_status_badge);
-            title        = itemView.findViewById(R.id.booking_title);
-            subtitle     = itemView.findViewById(R.id.booking_subtitle);
-            dateTime     = itemView.findViewById(R.id.booking_datetime);
-            duration     = itemView.findViewById(R.id.booking_duration);
-            guide        = itemView.findViewById(R.id.booking_guide);
-            detailButton = itemView.findViewById(R.id.booking_detail_button);
-            cancelButton = itemView.findViewById(R.id.booking_cancel_button);
-            reviewButton = itemView.findViewById(R.id.booking_review_button);
+            day           = itemView.findViewById(R.id.booking_day);
+            month         = itemView.findViewById(R.id.booking_month);
+            statusBadge   = itemView.findViewById(R.id.booking_status_badge);
+            title         = itemView.findViewById(R.id.booking_title);
+            subtitle      = itemView.findViewById(R.id.booking_subtitle);
+            dateTime      = itemView.findViewById(R.id.booking_datetime);
+            duration      = itemView.findViewById(R.id.booking_duration);
+            guide         = itemView.findViewById(R.id.booking_guide);
+            detailButton  = itemView.findViewById(R.id.booking_detail_button);
+            cancelButton  = itemView.findViewById(R.id.booking_cancel_button);
+            reviewButton  = itemView.findViewById(R.id.booking_review_button);
+            voucherButton = itemView.findViewById(R.id.booking_voucher_button);
         }
     }
 }

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -184,7 +184,6 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         button.setEnabled(enabled);
         button.setAlpha(alpha);
     }
-    }
 
     @Override
     public int getItemCount() {

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -134,23 +134,35 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
 
 
-        boolean isPendingCancel = "PENDING_CANCEL".equalsIgnoreCase(booking.status);
-        boolean canCancel = "CONFIRMED".equalsIgnoreCase(booking.status);
-        holder.cancelButton.setVisibility((canCancel && !isPendingCancel) ? View.VISIBLE : View.GONE);
-        holder.cancelButton.setEnabled(!isPendingCancel);
-        holder.cancelButton.setAlpha(isPendingCancel ? 0.5f : 1f);
+        // Estados
+        final boolean isPendingCancel = "PENDING_CANCEL".equalsIgnoreCase(booking.status);
+        final boolean isConfirmed = "CONFIRMED".equalsIgnoreCase(booking.status);
+        final boolean isCompleted = "COMPLETED".equalsIgnoreCase(booking.status);
+        final boolean canCancel = isConfirmed;
+        final boolean canVoucher = isConfirmed && !isPendingCancel;
+        final boolean canReview = booking.canReview && isCompleted && isWithinReviewWindow(booking.sessionStartTime, booking.durationMinutes);
+
+        // Utilidad para configurar botones
+        setButtonState(holder.cancelButton, (canCancel && !isPendingCancel), !isPendingCancel, isPendingCancel ? 0.5f : 1f);
+        setButtonState(holder.voucherButton, canVoucher, !isPendingCancel, isPendingCancel ? 0.5f : 1f);
+        setButtonState(holder.reviewButton, canReview, !offline, offline ? 0.45f : 1f);
+
         holder.cancelButton.setOnClickListener(v -> {
-            if (!isPendingCancel && cancelClickListener != null) cancelClickListener.onCancel(booking);
-            else if (isPendingCancel) {
+            if (!isPendingCancel && cancelClickListener != null) {
+                cancelClickListener.onCancel(booking);
+            } else if (isPendingCancel) {
                 Toast.makeText(v.getContext(), R.string.cancel_booking_pending_alert, Toast.LENGTH_SHORT).show();
             }
         });
 
-        boolean canReview = booking.canReview
-                && "COMPLETED".equalsIgnoreCase(booking.status)
-                && isWithinReviewWindow(booking.sessionStartTime, booking.durationMinutes);
-        holder.reviewButton.setVisibility(canReview ? View.VISIBLE : View.GONE);
-        holder.reviewButton.setAlpha(offline ? 0.45f : 1f);
+        holder.voucherButton.setOnClickListener(v -> {
+            if (!isPendingCancel && voucherClickListener != null) {
+                voucherClickListener.onVoucher(booking);
+            } else if (isPendingCancel) {
+                Toast.makeText(v.getContext(), R.string.cancel_booking_pending_alert, Toast.LENGTH_SHORT).show();
+            }
+        });
+
         holder.reviewButton.setOnClickListener(v -> {
             if (offline) {
                 Toast.makeText(v.getContext(), R.string.review_offline_error, Toast.LENGTH_SHORT).show();
@@ -162,18 +174,14 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         holder.detailButton.setOnClickListener(v -> {
             if (detailClickListener != null) detailClickListener.onDetail(booking);
         });
-
-        boolean isPendingCancel = "PENDING_CANCEL".equalsIgnoreCase(booking.status);
-        boolean canVoucher = "CONFIRMED".equalsIgnoreCase(booking.status) && !isPendingCancel;
-        holder.voucherButton.setVisibility(canVoucher ? View.VISIBLE : View.GONE);
-        holder.voucherButton.setEnabled(!isPendingCancel);
-        holder.voucherButton.setAlpha(isPendingCancel ? 0.5f : 1f);
-        holder.voucherButton.setOnClickListener(v -> {
-            if (!isPendingCancel && voucherClickListener != null) voucherClickListener.onVoucher(booking);
-            else if (isPendingCancel) {
-                Toast.makeText(v.getContext(), R.string.cancel_booking_pending_alert, Toast.LENGTH_SHORT).show();
-            }
-        });
+        /**
+         * Configura visibilidad, habilitación y alpha de un botón de forma DRY.
+         */
+        private void setButtonState(View button, boolean visible, boolean enabled, float alpha) {
+            button.setVisibility(visible ? View.VISIBLE : View.GONE);
+            button.setEnabled(enabled);
+            button.setAlpha(alpha);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -133,10 +133,17 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             holder.guide.setVisibility(View.GONE);
         }
 
+
+        boolean isPendingCancel = "PENDING_CANCEL".equalsIgnoreCase(booking.status);
         boolean canCancel = "CONFIRMED".equalsIgnoreCase(booking.status);
-        holder.cancelButton.setVisibility(canCancel ? View.VISIBLE : View.GONE);
+        holder.cancelButton.setVisibility((canCancel && !isPendingCancel) ? View.VISIBLE : View.GONE);
+        holder.cancelButton.setEnabled(!isPendingCancel);
+        holder.cancelButton.setAlpha(isPendingCancel ? 0.5f : 1f);
         holder.cancelButton.setOnClickListener(v -> {
-            if (cancelClickListener != null) cancelClickListener.onCancel(booking);
+            if (!isPendingCancel && cancelClickListener != null) cancelClickListener.onCancel(booking);
+            else if (isPendingCancel) {
+                Toast.makeText(v.getContext(), R.string.cancel_booking_pending_alert, Toast.LENGTH_SHORT).show();
+            }
         });
 
         boolean canReview = booking.canReview
@@ -192,6 +199,11 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 label = ctx.getString(R.string.status_cancelled);
                 bgColor = 0xFFFFEBEE;
                 textColor = 0xFFB71C1C;
+                break;
+            case "PENDING_CANCEL":
+                label = ctx.getString(R.string.status_pending_cancel);
+                bgColor = 0xFFFFF8E1;
+                textColor = 0xFFE65100;
                 break;
             case "PENDING":
                 label = ctx.getString(R.string.status_pending);

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingAdapter.java
@@ -163,10 +163,16 @@ public class BookingAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (detailClickListener != null) detailClickListener.onDetail(booking);
         });
 
-        boolean canVoucher = "CONFIRMED".equalsIgnoreCase(booking.status);
+        boolean isPendingCancel = "PENDING_CANCEL".equalsIgnoreCase(booking.status);
+        boolean canVoucher = "CONFIRMED".equalsIgnoreCase(booking.status) && !isPendingCancel;
         holder.voucherButton.setVisibility(canVoucher ? View.VISIBLE : View.GONE);
+        holder.voucherButton.setEnabled(!isPendingCancel);
+        holder.voucherButton.setAlpha(isPendingCancel ? 0.5f : 1f);
         holder.voucherButton.setOnClickListener(v -> {
-            if (voucherClickListener != null) voucherClickListener.onVoucher(booking);
+            if (!isPendingCancel && voucherClickListener != null) voucherClickListener.onVoucher(booking);
+            else if (isPendingCancel) {
+                Toast.makeText(v.getContext(), R.string.cancel_booking_pending_alert, Toast.LENGTH_SHORT).show();
+            }
         });
     }
 

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
@@ -238,8 +238,30 @@ public class BookingsFragment extends Fragment {
             if (items == null) return;
             summaryAdapter.updateData(items);
             boolean empty = items.isEmpty();
-            historialEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
+            // El mensaje se decide abajo según neverSynced
             historialRecycler.setVisibility(empty ? View.GONE : View.VISIBLE);
+        });
+
+        // Nuevo: observar si nunca se sincronizó
+        viewModel.isHistorialNeverSynced().observe(getViewLifecycleOwner(), neverSynced -> {
+            boolean show = false;
+            if (Boolean.TRUE.equals(neverSynced)) {
+                // Solo mostrar si además la lista está vacía
+                List<BookingSummaryItem> items = viewModel.getHistorial().getValue();
+                show = (items == null || items.isEmpty());
+            }
+            if (show) {
+                historialEmpty.setText(R.string.bookings_empty_historial_never_synced);
+                historialEmpty.setVisibility(View.VISIBLE);
+                historialRecycler.setVisibility(View.GONE);
+            } else {
+                // Restaurar mensaje por default si corresponde
+                List<BookingSummaryItem> items = viewModel.getHistorial().getValue();
+                boolean empty = (items == null || items.isEmpty());
+                historialEmpty.setText(R.string.bookings_empty_historial);
+                historialEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
+                historialRecycler.setVisibility(empty ? View.GONE : View.VISIBLE);
+            }
         });
 
         viewModel.getAvailableDestinations().observe(getViewLifecycleOwner(), destinations -> {

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
@@ -29,6 +29,7 @@ import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.ui.bookings.viewmodel.BookingsViewModel;
 import com.example.myapplication.ui.profile.ActivitySummaryAdapter;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -51,6 +52,7 @@ public class BookingsFragment extends Fragment {
     private BookingsViewModel viewModel;
     private View offlineBanner;
     private ConnectivityManager.NetworkCallback networkCallback;
+    private SwipeRefreshLayout swipeRefresh;
 
     // Activas views
     private View sectionActivas;
@@ -99,6 +101,7 @@ public class BookingsFragment extends Fragment {
 
     private void bindViews(@NonNull View view) {
         offlineBanner     = view.findViewById(R.id.offline_banner);
+        swipeRefresh      = view.findViewById(R.id.swipe_refresh);
         sectionActivas    = view.findViewById(R.id.section_activas);
         activasRecycler   = view.findViewById(R.id.bookings_recycler_view);
         activasLoading    = view.findViewById(R.id.bookings_loading_spinner);
@@ -117,13 +120,16 @@ public class BookingsFragment extends Fragment {
     }
 
     private void setupAdapters(@NonNull View view) {
-        bookingAdapter = new BookingAdapter(b -> viewModel.cancelBooking(b.id), this::showReviewDialog);
+        bookingAdapter = new BookingAdapter(this::showCancelDialog, this::showReviewDialog);
         bookingAdapter.setOnDetailClickListener(this::navigateToDetail);
+        bookingAdapter.setOnVoucherClickListener(this::navigateToVoucher);
         activasRecycler.setAdapter(bookingAdapter);
 
         summaryAdapter = new ActivitySummaryAdapter();
         summaryAdapter.setOnItemClickListener(this::navigateToHistoryDetail);
         historialRecycler.setAdapter(summaryAdapter);
+
+        swipeRefresh.setOnRefreshListener(() -> viewModel.loadMyBookings("CONFIRMED"));
     }
 
     private void setupFilters() {
@@ -205,13 +211,21 @@ public class BookingsFragment extends Fragment {
 
     private void observeViewModel(@NonNull View view) {
         viewModel.isLoading().observe(getViewLifecycleOwner(), loading -> {
-            activasLoading.setVisibility(Boolean.TRUE.equals(loading) ? View.VISIBLE : View.GONE);
+            boolean isLoading = Boolean.TRUE.equals(loading);
+            activasLoading.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+            if (!isLoading && swipeRefresh != null) swipeRefresh.setRefreshing(false);
         });
 
         viewModel.getBookings().observe(getViewLifecycleOwner(), bookings -> {
             List<BookingListItem> grouped = buildGroupedList(bookings);
             bookingAdapter.updateData(grouped);
             boolean empty = bookings == null || bookings.isEmpty();
+            if (empty) {
+                boolean offline = Boolean.TRUE.equals(viewModel.isOffline().getValue());
+                activasEmpty.setText(offline
+                        ? R.string.bookings_empty_offline
+                        : R.string.bookings_empty_activas);
+            }
             activasEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
             activasRecycler.setVisibility(empty ? View.GONE : View.VISIBLE);
         });
@@ -221,8 +235,9 @@ public class BookingsFragment extends Fragment {
         });
 
         viewModel.getHistorial().observe(getViewLifecycleOwner(), items -> {
+            if (items == null) return;
             summaryAdapter.updateData(items);
-            boolean empty = items == null || items.isEmpty();
+            boolean empty = items.isEmpty();
             historialEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
             historialRecycler.setVisibility(empty ? View.GONE : View.VISIBLE);
         });
@@ -249,8 +264,18 @@ public class BookingsFragment extends Fragment {
         });
 
         viewModel.isOffline().observe(getViewLifecycleOwner(), offline -> {
+            boolean isOffline = Boolean.TRUE.equals(offline);
             if (offlineBanner != null) {
-                offlineBanner.setVisibility(Boolean.TRUE.equals(offline) ? View.VISIBLE : View.GONE);
+                offlineBanner.setVisibility(isOffline ? View.VISIBLE : View.GONE);
+            }
+            if (bookingAdapter != null) {
+                bookingAdapter.setOffline(isOffline);
+            }
+            // Si la lista ya está vacía, actualizar el texto según el nuevo estado de red
+            if (activasEmpty != null && activasEmpty.getVisibility() == View.VISIBLE) {
+                activasEmpty.setText(isOffline
+                        ? R.string.bookings_empty_offline
+                        : R.string.bookings_empty_activas);
             }
         });
     }
@@ -334,9 +359,15 @@ public class BookingsFragment extends Fragment {
 
     private void navigateToDetail(BookingResponse booking) {
         if (booking.activityId == null) return;
+        String destination = booking.destination != null ? booking.destination.name : "";
+        String duration = booking.durationMinutes > 0 ? booking.durationMinutes + " min" : "";
+        String price = booking.currency != null
+                ? booking.totalPrice + " " + booking.currency : String.valueOf(booking.totalPrice);
         TourActivity activity = new TourActivity(
                 booking.activityName != null ? booking.activityName : "",
-                "", "", "", "", 0, null);
+                destination, "", duration, price, 0, null,
+                null, 0f, 0, null, booking.meetingPoint,
+                booking.guideName, null, booking.cancellationPolicy, null);
         activity.setId(booking.activityId);
         Bundle args = new Bundle();
         args.putSerializable("activity_data", activity);
@@ -345,15 +376,30 @@ public class BookingsFragment extends Fragment {
                 .navigate(R.id.action_bookingsFragment_to_detailFragment, args);
     }
 
+    private void navigateToVoucher(BookingResponse booking) {
+        if (booking.id == null) return;
+        Bundle args = new Bundle();
+        args.putLong("bookingId", booking.id);
+        Navigation.findNavController(requireView())
+                .navigate(R.id.action_bookingsFragment_to_voucherFragment, args);
+    }
+
     private void navigateToHistoryDetail(BookingSummaryItem item) {
         if (item.getActivityId() == null) return;
+        String duration = item.getDurationMinutes() > 0 ? item.getDurationMinutes() + " min" : "";
         TourActivity activity = new TourActivity(
-                item.getActivityName(), "", "", "", "", 0, item.getImageUrl());
+                item.getActivityName() != null ? item.getActivityName() : "",
+                item.getDestination() != null ? item.getDestination() : "",
+                "", duration,
+                item.getPrice() != null ? item.getPrice() : "",
+                0, item.getImageUrl(),
+                null, 0f, 0, null, null,
+                item.getGuideName(), null, null, null);
         activity.setId(item.getActivityId());
         Bundle args = new Bundle();
         args.putSerializable("activity_data", activity);
         args.putBoolean("from_history", true);
-        args.putString("booking_status", "COMPLETED");
+        args.putString("booking_status", item.getStatus() != null ? item.getStatus() : "");
         if (item.getId() != null) args.putLong("booking_id", item.getId());
         Navigation.findNavController(requireView())
                 .navigate(R.id.action_bookingsFragment_to_detailFragment, args);
@@ -385,6 +431,7 @@ public class BookingsFragment extends Fragment {
             networkCallback = null;
         }
         offlineBanner     = null;
+        swipeRefresh      = null;
         sectionActivas    = null;
         activasRecycler   = null;
         activasLoading    = null;
@@ -401,6 +448,20 @@ public class BookingsFragment extends Fragment {
         btnBuscar         = null;
         btnLimpiar        = null;
         super.onDestroyView();
+    }
+
+    private void showCancelDialog(BookingResponse booking) {
+        if (booking == null || booking.id == null) return;
+        String policy = (booking.cancellationPolicy != null && !booking.cancellationPolicy.isEmpty())
+                ? booking.cancellationPolicy
+                : getString(R.string.cancel_booking_policy_unknown);
+        String name = booking.activityName != null ? booking.activityName : "";
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.cancel_booking_title)
+                .setMessage(getString(R.string.cancel_booking_message, name, policy))
+                .setPositiveButton(R.string.cancel_booking_confirm, (d, w) -> viewModel.cancelBooking(booking.id))
+                .setNegativeButton(R.string.cancel_booking_back, null)
+                .show();
     }
 
     private void showReviewDialog(BookingResponse booking) {

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
@@ -285,6 +285,16 @@ public class BookingsFragment extends Fragment {
             }
         });
 
+        viewModel.isShowOfflineCancelModal().observe(getViewLifecycleOwner(), show -> {
+            if (Boolean.TRUE.equals(show)) {
+                new com.google.android.material.dialog.MaterialAlertDialogBuilder(requireContext())
+                        .setMessage(R.string.cancel_booking_offline_modal)
+                        .setPositiveButton(android.R.string.ok, null)
+                        .show();
+                viewModel.clearOfflineCancelModal();
+            }
+        });
+
         viewModel.isOffline().observe(getViewLifecycleOwner(), offline -> {
             boolean isOffline = Boolean.TRUE.equals(offline);
             if (offlineBanner != null) {
@@ -380,14 +390,23 @@ public class BookingsFragment extends Fragment {
     // ── Navigation ────────────────────────────────────────────────────────────
 
     private void navigateToDetail(BookingResponse booking) {
-        if (booking.activityId == null) return;
+        // Sin conexión: el detalle de la actividad requiere red. Mostrar el voucher que está cacheado.
+        if (Boolean.TRUE.equals(viewModel.isOffline().getValue())) {
+            navigateToVoucher(booking);
+            return;
+        }
+        // Si por algún motivo no hay activityId, caer al voucher en lugar de silenciar.
+        if (booking.activityId == null) {
+            navigateToVoucher(booking);
+            return;
+        }
         String destination = booking.destination != null ? booking.destination.name : "";
         String duration = booking.durationMinutes > 0 ? booking.durationMinutes + " min" : "";
         String price = booking.currency != null
                 ? booking.totalPrice + " " + booking.currency : String.valueOf(booking.totalPrice);
         TourActivity activity = new TourActivity(
                 booking.activityName != null ? booking.activityName : "",
-                destination, "", duration, price, 0, null,
+                destination, "", duration, price, -1, null,
                 null, 0f, 0, null, booking.meetingPoint,
                 booking.guideName, null, booking.cancellationPolicy, null);
         activity.setId(booking.activityId);

--- a/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/BookingsFragment.java
@@ -6,8 +6,6 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,6 +27,7 @@ import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.ui.bookings.viewmodel.BookingsViewModel;
 import com.example.myapplication.ui.profile.ActivitySummaryAdapter;
+import com.example.myapplication.util.MainThreadUtils;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButton;
@@ -319,14 +318,14 @@ public class BookingsFragment extends Fragment {
         networkCallback = new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(Network network) {
-                new Handler(Looper.getMainLooper()).post(() -> {
+                MainThreadUtils.post(() -> {
                     if (isAdded()) viewModel.onConnectivityChanged(true);
                 });
             }
 
             @Override
             public void onLost(Network network) {
-                new Handler(Looper.getMainLooper()).post(() -> {
+                MainThreadUtils.post(() -> {
                     if (isAdded()) viewModel.onConnectivityChanged(false);
                 });
             }
@@ -390,29 +389,21 @@ public class BookingsFragment extends Fragment {
     // ── Navigation ────────────────────────────────────────────────────────────
 
     private void navigateToDetail(BookingResponse booking) {
-        // Sin conexión: el detalle de la actividad requiere red. Mostrar el voucher que está cacheado.
-        if (Boolean.TRUE.equals(viewModel.isOffline().getValue())) {
-            navigateToVoucher(booking);
-            return;
-        }
-        // Si por algún motivo no hay activityId, caer al voucher en lugar de silenciar.
-        if (booking.activityId == null) {
-            navigateToVoucher(booking);
-            return;
-        }
         String destination = booking.destination != null ? booking.destination.name : "";
         String duration = booking.durationMinutes > 0 ? booking.durationMinutes + " min" : "";
         String price = booking.currency != null
                 ? booking.totalPrice + " " + booking.currency : String.valueOf(booking.totalPrice);
         TourActivity activity = new TourActivity(
                 booking.activityName != null ? booking.activityName : "",
-                destination, "", duration, price, -1, null,
+                destination, "", duration, price, 1, null,
                 null, 0f, 0, null, booking.meetingPoint,
                 booking.guideName, null, booking.cancellationPolicy, null);
-        activity.setId(booking.activityId);
+        if (booking.activityId != null) activity.setId(booking.activityId);
         Bundle args = new Bundle();
         args.putSerializable("activity_data", activity);
-        args.putBoolean("from_history", false);
+        args.putBoolean("from_history", true);
+        args.putString("booking_status", booking.status != null ? booking.status : "CONFIRMED");
+        if (booking.id != null) args.putLong("booking_id", booking.id);
         Navigation.findNavController(requireView())
                 .navigate(R.id.action_bookingsFragment_to_detailFragment, args);
     }

--- a/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
@@ -1,0 +1,255 @@
+package com.example.myapplication.ui.bookings;
+
+import android.content.ContentValues;
+import android.content.Intent;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.pdf.PdfDocument;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
+import com.example.myapplication.R;
+import com.example.myapplication.data.local.OfflineBookingEntity;
+import com.example.myapplication.util.FormatUtils;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
+import dagger.hilt.android.AndroidEntryPoint;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@AndroidEntryPoint
+public class VoucherFragment extends Fragment {
+
+    private VoucherViewModel viewModel;
+    private OfflineBookingEntity currentBooking;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_voucher, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        MaterialToolbar toolbar = view.findViewById(R.id.voucher_toolbar);
+        toolbar.setNavigationOnClickListener(v -> Navigation.findNavController(view).navigateUp());
+
+        MaterialButton downloadButton = view.findViewById(R.id.voucher_download_button);
+        downloadButton.setOnClickListener(v -> generatePdf());
+
+        viewModel = new ViewModelProvider(this).get(VoucherViewModel.class);
+        viewModel.getBooking().observe(getViewLifecycleOwner(), booking -> {
+            if (booking != null) {
+                currentBooking = booking;
+                bindData(view, booking);
+            }
+        });
+    }
+
+    private void bindData(View view, OfflineBookingEntity b) {
+        setText(view, R.id.voucher_activity_name, b.activityName);
+        setText(view, R.id.voucher_destination, b.destinationName);
+        setText(view, R.id.voucher_datetime, FormatUtils.formatStartTime(b.sessionStartTime));
+        setText(view, R.id.voucher_duration, FormatUtils.formatDuration(b.durationMinutes));
+        setText(view, R.id.voucher_participants,
+                requireContext().getString(R.string.voucher_participants, b.participants));
+        setText(view, R.id.voucher_price, FormatUtils.formatPrice(b.totalPrice, b.currency));
+
+        View guideRow = view.findViewById(R.id.voucher_guide_row);
+        if (b.guideName != null && !b.guideName.isEmpty()) {
+            setText(view, R.id.voucher_guide, b.guideName);
+            if (guideRow != null) guideRow.setVisibility(View.VISIBLE);
+        } else {
+            if (guideRow != null) guideRow.setVisibility(View.GONE);
+        }
+
+        View meetingRow = view.findViewById(R.id.voucher_meeting_point_row);
+        if (b.meetingPoint != null && !b.meetingPoint.isEmpty()) {
+            setText(view, R.id.voucher_meeting_point, b.meetingPoint);
+            if (meetingRow != null) meetingRow.setVisibility(View.VISIBLE);
+        } else {
+            if (meetingRow != null) meetingRow.setVisibility(View.GONE);
+        }
+
+        setText(view, R.id.voucher_code, b.voucherCode != null ? b.voucherCode : "—");
+    }
+
+    private void generatePdf() {
+        if (currentBooking == null) return;
+
+        PdfDocument document = new PdfDocument();
+        PdfDocument.PageInfo pageInfo = new PdfDocument.PageInfo.Builder(595, 842, 1).create();
+        PdfDocument.Page page = document.startPage(pageInfo);
+        Canvas canvas = page.getCanvas();
+
+        drawPdf(canvas, currentBooking);
+        document.finishPage(page);
+
+        String fileName = "voucher_" + (currentBooking.voucherCode != null
+                ? currentBooking.voucherCode : currentBooking.id) + ".pdf";
+
+        try {
+            Uri uri = savePdf(document, fileName);
+            document.close();
+            if (uri != null) {
+                Toast.makeText(requireContext(), R.string.voucher_pdf_saved, Toast.LENGTH_LONG).show();
+                openPdf(uri);
+            } else {
+                Toast.makeText(requireContext(), R.string.voucher_pdf_error, Toast.LENGTH_SHORT).show();
+            }
+        } catch (IOException e) {
+            document.close();
+            Toast.makeText(requireContext(), R.string.voucher_pdf_error, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void drawPdf(Canvas canvas, OfflineBookingEntity b) {
+        int margin = 48;
+        int y = 60;
+
+        Paint titlePaint = new Paint();
+        titlePaint.setColor(Color.parseColor("#1A1A1A"));
+        titlePaint.setTextSize(22f);
+        titlePaint.setFakeBoldText(true);
+
+        Paint labelPaint = new Paint();
+        labelPaint.setColor(Color.parseColor("#757575"));
+        labelPaint.setTextSize(11f);
+
+        Paint valuePaint = new Paint();
+        valuePaint.setColor(Color.parseColor("#1A1A1A"));
+        valuePaint.setTextSize(14f);
+        valuePaint.setFakeBoldText(true);
+
+        Paint codePaint = new Paint();
+        codePaint.setColor(Color.parseColor("#7C3AED"));
+        codePaint.setTextSize(24f);
+        codePaint.setFakeBoldText(true);
+
+        Paint dividerPaint = new Paint();
+        dividerPaint.setColor(Color.parseColor("#E0E0E0"));
+        dividerPaint.setStrokeWidth(1f);
+
+        Paint headerPaint = new Paint();
+        headerPaint.setColor(Color.parseColor("#1B5E20"));
+        headerPaint.setTextSize(16f);
+        headerPaint.setFakeBoldText(true);
+
+        // Header
+        canvas.drawText("XploreNow", margin, y, headerPaint);
+        y += 10;
+        canvas.drawLine(margin, y, 595 - margin, y, dividerPaint);
+        y += 30;
+
+        // Activity name
+        canvas.drawText(safe(b.activityName), margin, y, titlePaint);
+        y += 24;
+
+        if (b.destinationName != null) {
+            canvas.drawText(b.destinationName, margin, y, labelPaint);
+            y += 30;
+        }
+
+        canvas.drawLine(margin, y, 595 - margin, y, dividerPaint);
+        y += 24;
+
+        // Fields
+        y = drawField(canvas, margin, y, "Fecha y hora",
+                FormatUtils.formatStartTime(b.sessionStartTime), labelPaint, valuePaint);
+        if (b.meetingPoint != null && !b.meetingPoint.isEmpty()) {
+            y = drawField(canvas, margin, y, "Punto de encuentro", b.meetingPoint, labelPaint, valuePaint);
+        }
+        y = drawField(canvas, margin, y, "Duración",
+                FormatUtils.formatDuration(b.durationMinutes), labelPaint, valuePaint);
+        if (b.guideName != null && !b.guideName.isEmpty()) {
+            y = drawField(canvas, margin, y, "Guía", b.guideName, labelPaint, valuePaint);
+        }
+        y = drawField(canvas, margin, y, "Participantes",
+                b.participants + " participante(s)", labelPaint, valuePaint);
+        y = drawField(canvas, margin, y, "Precio total",
+                FormatUtils.formatPrice(b.totalPrice, b.currency), labelPaint, valuePaint);
+
+        y += 10;
+        canvas.drawLine(margin, y, 595 - margin, y, dividerPaint);
+        y += 30;
+
+        // Code
+        Paint codeLabel = new Paint();
+        codeLabel.setColor(Color.parseColor("#757575"));
+        codeLabel.setTextSize(11f);
+        canvas.drawText("CÓDIGO DE RESERVA", margin, y, codeLabel);
+        y += 24;
+        canvas.drawText(safe(b.voucherCode), margin, y, codePaint);
+        y += 16;
+
+        Paint hintPaint = new Paint();
+        hintPaint.setColor(Color.parseColor("#9E9E9E"));
+        hintPaint.setTextSize(11f);
+        canvas.drawText("Mostrá este código el día de la actividad", margin, y, hintPaint);
+    }
+
+    private int drawField(Canvas c, int x, int y, String label, String value,
+                          Paint labelPaint, Paint valuePaint) {
+        c.drawText(label, x, y, labelPaint);
+        c.drawText(value != null ? value : "—", x, y + 18, valuePaint);
+        return y + 46;
+    }
+
+    @Nullable
+    private Uri savePdf(PdfDocument document, String fileName) throws IOException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.Downloads.DISPLAY_NAME, fileName);
+            values.put(MediaStore.Downloads.MIME_TYPE, "application/pdf");
+            values.put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
+            Uri uri = requireContext().getContentResolver()
+                    .insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
+            if (uri == null) return null;
+            try (OutputStream out = requireContext().getContentResolver().openOutputStream(uri)) {
+                document.writeTo(out);
+            }
+            return uri;
+        } else {
+            java.io.File dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            java.io.File file = new java.io.File(dir, fileName);
+            try (OutputStream out = new java.io.FileOutputStream(file)) {
+                document.writeTo(out);
+            }
+            return Uri.fromFile(file);
+        }
+    }
+
+    private void openPdf(Uri uri) {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(uri, "application/pdf");
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        try {
+            startActivity(intent);
+        } catch (Exception ignored) {}
+    }
+
+    private void setText(View root, int id, String text) {
+        TextView tv = root.findViewById(id);
+        if (tv != null) tv.setText(text != null ? text : "");
+    }
+
+    private String safe(String s) {
+        return s != null ? s : "—";
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/bookings/VoucherViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/VoucherViewModel.java
@@ -1,0 +1,39 @@
+package com.example.myapplication.ui.bookings;
+
+import android.os.Handler;
+import android.os.Looper;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.SavedStateHandle;
+import androidx.lifecycle.ViewModel;
+import com.example.myapplication.data.local.OfflineBookingDao;
+import com.example.myapplication.data.local.OfflineBookingEntity;
+import dagger.hilt.android.lifecycle.HiltViewModel;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import javax.inject.Inject;
+
+@HiltViewModel
+public class VoucherViewModel extends ViewModel {
+
+    private final OfflineBookingDao offlineBookingDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
+    private final MutableLiveData<OfflineBookingEntity> _booking = new MutableLiveData<>();
+
+    public LiveData<OfflineBookingEntity> getBooking() { return _booking; }
+
+    @Inject
+    public VoucherViewModel(OfflineBookingDao offlineBookingDao, SavedStateHandle savedStateHandle) {
+        this.offlineBookingDao = offlineBookingDao;
+        long bookingId = savedStateHandle.get("bookingId") != null
+                ? savedStateHandle.<Long>get("bookingId") : -1L;
+        if (bookingId > 0) load(bookingId);
+    }
+
+    public void load(long bookingId) {
+        dbExecutor.execute(() -> {
+            OfflineBookingEntity entity = offlineBookingDao.getById(bookingId);
+            new Handler(Looper.getMainLooper()).post(() -> _booking.setValue(entity));
+        });
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
@@ -1,8 +1,6 @@
 package com.example.myapplication.ui.bookings.viewmodel;
 
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkCapabilities;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
@@ -18,6 +16,7 @@ import com.example.myapplication.data.repository.BookingRepository;
 import com.example.myapplication.data.repository.ProfileRepository;
 import com.example.myapplication.data.repository.ReviewRepository;
 import com.example.myapplication.data.work.SyncCancellationsWorker;
+import com.example.myapplication.util.ConnectivityUtils;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
 import androidx.work.ExistingWorkPolicy;
@@ -80,7 +79,7 @@ public class BookingsViewModel extends ViewModel {
         this.profileRepository = profileRepository;
         this.reviewRepository = reviewRepository;
         this.context = context;
-        this.offline = !isOnline();
+        this.offline = !ConnectivityUtils.isOnline(context);
         if (this.offline) _isOffline.setValue(true);
     }
 
@@ -373,14 +372,6 @@ public class BookingsViewModel extends ViewModel {
                         _error.setValue(error);
                     }
                 });
-    }
-
-    private boolean isOnline() {
-        ConnectivityManager cm =
-                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (cm == null) return false;
-        NetworkCapabilities caps = cm.getNetworkCapabilities(cm.getActiveNetwork());
-        return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
@@ -63,6 +63,9 @@ public class BookingsViewModel extends ViewModel {
     private List<BookingResponse> reconnectPendingSnapshot = null;
     private int selectedTab = 0;
 
+    // Nuevo: flag para historial nunca sincronizado
+    private final MutableLiveData<Boolean> _historialNeverSynced = new MutableLiveData<>(false);
+
     @Inject
     public BookingsViewModel(BookingRepository bookingRepository,
                              ProfileRepository profileRepository,
@@ -88,6 +91,9 @@ public class BookingsViewModel extends ViewModel {
 
     public LiveData<List<BookingSummaryItem>> getHistorial() { return _historial; }
     public LiveData<Boolean> isHistorialLoading() { return _historialLoading; }
+
+    // Nuevo getter
+    public LiveData<Boolean> isHistorialNeverSynced() { return _historialNeverSynced; }
     public LiveData<List<String>> getAvailableDestinations() { return _availableDestinations; }
 
     public void clearMessage() { _message.setValue(null); }
@@ -272,6 +278,10 @@ public class BookingsViewModel extends ViewModel {
             updateDestinationSuggestions();
             applyFilters();
             _historialLoading.setValue(false);
+
+            // Nuevo: si nunca hubo datos sincronizados
+            boolean neverSynced = (cachedServerHistorialItems == null || cachedServerHistorialItems.isEmpty());
+            _historialNeverSynced.setValue(neverSynced);
             return;
         }
 
@@ -290,6 +300,9 @@ public class BookingsViewModel extends ViewModel {
                 updateDestinationSuggestions();
                 applyFilters();
                 _historialLoading.setValue(false);
+
+                // Nuevo: si hubo datos sincronizados, nuncaSynced = false
+                _historialNeverSynced.setValue(false);
             }
 
             @Override
@@ -309,6 +322,8 @@ public class BookingsViewModel extends ViewModel {
                 allHistorialItems = all;
                 applyFilters();
                 _historialLoading.setValue(false);
+                boolean neverSynced = (cachedServerHistorialItems == null || cachedServerHistorialItems.isEmpty());
+                _historialNeverSynced.setValue(neverSynced);
                 if (all.isEmpty()) _error.setValue(error);
             }
         });

--- a/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
@@ -5,12 +5,9 @@ import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModel;
-import androidx.work.BackoffPolicy;
-import androidx.work.Constraints;
-import androidx.work.ExistingWorkPolicy;
-import androidx.work.NetworkType;
-import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import com.example.myapplication.R;
 import com.example.myapplication.data.common.RepositoryCallback;
@@ -21,6 +18,11 @@ import com.example.myapplication.data.repository.BookingRepository;
 import com.example.myapplication.data.repository.ProfileRepository;
 import com.example.myapplication.data.repository.ReviewRepository;
 import com.example.myapplication.data.work.SyncCancellationsWorker;
+import androidx.work.BackoffPolicy;
+import androidx.work.Constraints;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.OneTimeWorkRequest;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import java.util.ArrayList;
@@ -46,6 +48,7 @@ public class BookingsViewModel extends ViewModel {
     private final MutableLiveData<UiMessage> _message = new MutableLiveData<>();
     private final MutableLiveData<Boolean> _loading = new MutableLiveData<>(false);
     private final MutableLiveData<Boolean> _isOffline = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> _showOfflineCancelModal = new MutableLiveData<>(false);
     private boolean offline = false;
     private String currentFilter = null;
 
@@ -60,11 +63,13 @@ public class BookingsViewModel extends ViewModel {
     private String filterTo = "";
     private boolean historialLoaded = false;
     private List<BookingSummaryItem> cachedServerHistorialItems = Collections.emptyList();
-    private List<BookingResponse> reconnectPendingSnapshot = null;
     private int selectedTab = 0;
 
-    // Nuevo: flag para historial nunca sincronizado
     private final MutableLiveData<Boolean> _historialNeverSynced = new MutableLiveData<>(false);
+
+    // WorkManager sync observation
+    private LiveData<List<WorkInfo>> syncWorkInfoLiveData;
+    private Observer<List<WorkInfo>> syncWorkObserver;
 
     @Inject
     public BookingsViewModel(BookingRepository bookingRepository,
@@ -85,18 +90,18 @@ public class BookingsViewModel extends ViewModel {
     public LiveData<UiMessage> getMessage() { return _message; }
     public LiveData<Boolean> isLoading() { return _loading; }
     public LiveData<Boolean> isOffline() { return _isOffline; }
+    public LiveData<Boolean> isShowOfflineCancelModal() { return _showOfflineCancelModal; }
 
     public int getSelectedTab() { return selectedTab; }
     public void setSelectedTab(int tab) { selectedTab = tab; }
 
     public LiveData<List<BookingSummaryItem>> getHistorial() { return _historial; }
     public LiveData<Boolean> isHistorialLoading() { return _historialLoading; }
-
-    // Nuevo getter
     public LiveData<Boolean> isHistorialNeverSynced() { return _historialNeverSynced; }
     public LiveData<List<String>> getAvailableDestinations() { return _availableDestinations; }
 
     public void clearMessage() { _message.setValue(null); }
+    public void clearOfflineCancelModal() { _showOfflineCancelModal.setValue(false); }
 
     // ── Activas actions ──────────────────────────────────────────────────────
 
@@ -104,26 +109,11 @@ public class BookingsViewModel extends ViewModel {
         offline = !isOnline;
         _isOffline.setValue(offline);
         if (isOnline) {
-            // Leer el snapshot de Room ANTES de encolar el WorkManager para evitar la race condition
-            // donde el worker borra la fila de pendingCancel antes de que loadHistorial pueda leerla.
-            bookingRepository.loadCachedPendingCancellations(new RepositoryCallback<List<BookingResponse>>() {
-                @Override
-                public void onSuccess(List<BookingResponse> snapshot) {
-                    reconnectPendingSnapshot = snapshot != null ? snapshot : Collections.emptyList();
-                    enqueueSyncWorker();
-                    loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
-                    historialLoaded = false;
-                    if (selectedTab == 1) loadHistorial();
-                }
-                @Override
-                public void onError(UiMessage e) {
-                    reconnectPendingSnapshot = Collections.emptyList();
-                    enqueueSyncWorker();
-                    loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
-                    historialLoaded = false;
-                    if (selectedTab == 1) loadHistorial();
-                }
-            });
+            enqueueSyncWorker();
+            observeSyncWorker();
+            loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
+            historialLoaded = false;
+            if (selectedTab == 1) loadHistorial();
         } else {
             loadCachedBookings();
         }
@@ -141,9 +131,35 @@ public class BookingsViewModel extends ViewModel {
                 "sync_cancellations", ExistingWorkPolicy.KEEP, syncWork);
     }
 
+    private void observeSyncWorker() {
+        if (syncWorkObserver != null && syncWorkInfoLiveData != null) {
+            syncWorkInfoLiveData.removeObserver(syncWorkObserver);
+        }
+        syncWorkInfoLiveData = WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkLiveData("sync_cancellations");
+        syncWorkObserver = workInfos -> {
+            if (workInfos == null || workInfos.isEmpty()) return;
+            WorkInfo info = workInfos.get(0);
+            if (info.getState().isFinished()) {
+                if (info.getState() == WorkInfo.State.SUCCEEDED) {
+                    int failedCount = info.getOutputData().getInt("failed_count", 0);
+                    if (failedCount > 0) {
+                        _message.postValue(UiMessage.from(R.string.cancel_sync_error));
+                        loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
+                    }
+                }
+                if (syncWorkInfoLiveData != null && syncWorkObserver != null) {
+                    syncWorkInfoLiveData.removeObserver(syncWorkObserver);
+                    syncWorkObserver = null;
+                    syncWorkInfoLiveData = null;
+                }
+            }
+        };
+        syncWorkInfoLiveData.observeForever(syncWorkObserver);
+    }
+
     public void loadMyBookings(String statusFilter) {
         currentFilter = statusFilter;
-        // Capturar IDs actuales antes del refresh para detectar cancelaciones del servidor (O17)
         final Set<Long> prevIds = new HashSet<>();
         if ("CONFIRMED".equals(statusFilter)) {
             List<BookingResponse> cur = _bookings.getValue();
@@ -203,9 +219,8 @@ public class BookingsViewModel extends ViewModel {
         if (offline) {
             bookingRepository.cancelBookingLocally(bookingId, () -> {
                 _message.setValue(UiMessage.from(R.string.cancel_booking_offline_queued));
+                _showOfflineCancelModal.setValue(true);
                 loadMyBookings(currentFilter);
-                historialLoaded = false;
-                if (selectedTab == 1) loadHistorial();
             });
             return;
         }
@@ -237,51 +252,33 @@ public class BookingsViewModel extends ViewModel {
 
     public void loadHistorial() {
         _historialLoading.setValue(true);
-        if (reconnectPendingSnapshot != null) {
-            List<BookingResponse> snapshot = reconnectPendingSnapshot;
-            reconnectPendingSnapshot = null;
-            fetchHistorialWithPending(snapshot);
-            return;
-        }
-        bookingRepository.loadCachedPendingCancellations(new RepositoryCallback<List<BookingResponse>>() {
-            @Override
-            public void onSuccess(List<BookingResponse> pending) {
-                fetchHistorialWithPending(pending);
-            }
-            @Override
-            public void onError(UiMessage e) {
-                fetchHistorialWithPending(null);
-            }
-        });
+        fetchHistorial();
     }
 
-    // pending == null indica fallo de DB: se omite el merge y se usa solo el servidor.
-    private void fetchHistorialWithPending(List<BookingResponse> pending) {
-        List<BookingSummaryItem> pendingItems = new ArrayList<>();
-        Set<Long> pendingIds = new java.util.HashSet<>();
-        if (pending != null) {
-            for (BookingResponse p : pending) {
-                BookingSummaryItem item = toSummaryItem(p);
-                pendingItems.add(item);
-                if (p.id != null) pendingIds.add(p.id);
-            }
-        }
-
-        // Sin red: usar datos locales directamente sin esperar timeout de red
+    private void fetchHistorial() {
         if (offline) {
-            historialLoaded = true;
-            List<BookingSummaryItem> all = new ArrayList<>(pendingItems);
-            for (BookingSummaryItem cached : cachedServerHistorialItems) {
-                if (cached.getId() == null || !pendingIds.contains(cached.getId())) all.add(cached);
-            }
-            allHistorialItems = all;
-            updateDestinationSuggestions();
-            applyFilters();
-            _historialLoading.setValue(false);
+            bookingRepository.loadCachedHistorial(new RepositoryCallback<List<BookingSummaryItem>>() {
+                @Override
+                public void onSuccess(List<BookingSummaryItem> roomItems) {
+                    cachedServerHistorialItems = roomItems != null ? roomItems : Collections.emptyList();
+                    historialLoaded = true;
+                    allHistorialItems = new ArrayList<>(cachedServerHistorialItems);
+                    updateDestinationSuggestions();
+                    applyFilters();
+                    _historialLoading.setValue(false);
+                    _historialNeverSynced.setValue(cachedServerHistorialItems.isEmpty());
+                }
 
-            // Nuevo: si nunca hubo datos sincronizados
-            boolean neverSynced = (cachedServerHistorialItems == null || cachedServerHistorialItems.isEmpty());
-            _historialNeverSynced.setValue(neverSynced);
+                @Override
+                public void onError(UiMessage e) {
+                    historialLoaded = true;
+                    allHistorialItems = Collections.emptyList();
+                    updateDestinationSuggestions();
+                    applyFilters();
+                    _historialLoading.setValue(false);
+                    _historialNeverSynced.setValue(true);
+                }
+            });
             return;
         }
 
@@ -291,62 +288,25 @@ public class BookingsViewModel extends ViewModel {
                 List<BookingSummaryItem> serverItems = data != null ? data : Collections.emptyList();
                 cachedServerHistorialItems = serverItems;
                 historialLoaded = true;
-                List<BookingSummaryItem> all = new ArrayList<>();
-                for (BookingSummaryItem p : pendingItems) {
-                    if (p.getId() == null || !containsId(serverItems, p.getId())) all.add(p);
-                }
-                all.addAll(serverItems);
-                allHistorialItems = all;
+                allHistorialItems = new ArrayList<>(serverItems);
                 updateDestinationSuggestions();
                 applyFilters();
                 _historialLoading.setValue(false);
-
-                // Nuevo: si hubo datos sincronizados, nuncaSynced = false
                 _historialNeverSynced.setValue(false);
             }
 
             @Override
             public void onError(UiMessage error) {
                 historialLoaded = true;
-                List<BookingSummaryItem> all = new ArrayList<>();
-                if (pending == null) {
-                    // DB también falló: usar solo caché del servidor anterior
-                    all.addAll(cachedServerHistorialItems);
-                } else {
-                    all.addAll(pendingItems);
-                    for (BookingSummaryItem cached : cachedServerHistorialItems) {
-                        if (cached.getId() == null || !pendingIds.contains(cached.getId())) all.add(cached);
-                    }
-                    updateDestinationSuggestions();
-                }
-                allHistorialItems = all;
+                allHistorialItems = new ArrayList<>(cachedServerHistorialItems);
+                updateDestinationSuggestions();
                 applyFilters();
                 _historialLoading.setValue(false);
-                boolean neverSynced = (cachedServerHistorialItems == null || cachedServerHistorialItems.isEmpty());
+                boolean neverSynced = cachedServerHistorialItems.isEmpty();
                 _historialNeverSynced.setValue(neverSynced);
-                if (all.isEmpty()) _error.setValue(error);
+                if (allHistorialItems.isEmpty()) _error.setValue(error);
             }
         });
-    }
-
-    private static boolean containsId(List<BookingSummaryItem> items, Long id) {
-        for (BookingSummaryItem item : items) {
-            if (id.equals(item.getId())) return true;
-        }
-        return false;
-    }
-
-    private BookingSummaryItem toSummaryItem(BookingResponse b) {
-        String date = "";
-        String time = "";
-        if (b.sessionStartTime != null && b.sessionStartTime.length() >= 10) {
-            date = b.sessionStartTime.substring(0, 10);
-            if (b.sessionStartTime.length() >= 16) time = b.sessionStartTime.substring(11, 16);
-        }
-        String price = b.currency != null ? b.totalPrice + " " + b.currency : "";
-        String destination = b.destination != null ? b.destination.name : "";
-        return new BookingSummaryItem(b.id, b.activityId, b.activityName,
-                b.status, date, price, destination, b.guideName, b.durationMinutes, null, time);
     }
 
     public void setFilterDestination(String destination) {
@@ -425,6 +385,9 @@ public class BookingsViewModel extends ViewModel {
 
     @Override
     protected void onCleared() {
+        if (syncWorkInfoLiveData != null && syncWorkObserver != null) {
+            syncWorkInfoLiveData.removeObserver(syncWorkObserver);
+        }
         bookingRepository.cancelAll();
         profileRepository.cancelAll();
         reviewRepository.cancelAll();

--- a/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
@@ -6,6 +6,12 @@ import android.net.NetworkCapabilities;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.work.BackoffPolicy;
+import androidx.work.Constraints;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
 import com.example.myapplication.R;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
@@ -14,13 +20,16 @@ import com.example.myapplication.data.model.BookingSummaryItem;
 import com.example.myapplication.data.repository.BookingRepository;
 import com.example.myapplication.data.repository.ProfileRepository;
 import com.example.myapplication.data.repository.ReviewRepository;
+import com.example.myapplication.data.work.SyncCancellationsWorker;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 @HiltViewModel
@@ -41,8 +50,7 @@ public class BookingsViewModel extends ViewModel {
     private String currentFilter = null;
 
     // ── Historial ────────────────────────────────────────────────────────────
-    private final MutableLiveData<List<BookingSummaryItem>> _historial =
-            new MutableLiveData<>(Collections.emptyList());
+    private final MutableLiveData<List<BookingSummaryItem>> _historial = new MutableLiveData<>();
     private final MutableLiveData<Boolean> _historialLoading = new MutableLiveData<>(false);
     private final MutableLiveData<List<String>> _availableDestinations =
             new MutableLiveData<>(Collections.emptyList());
@@ -51,6 +59,8 @@ public class BookingsViewModel extends ViewModel {
     private String filterFrom = "";
     private String filterTo = "";
     private boolean historialLoaded = false;
+    private List<BookingSummaryItem> cachedServerHistorialItems = Collections.emptyList();
+    private List<BookingResponse> reconnectPendingSnapshot = null;
     private int selectedTab = 0;
 
     @Inject
@@ -88,15 +98,53 @@ public class BookingsViewModel extends ViewModel {
         offline = !isOnline;
         _isOffline.setValue(offline);
         if (isOnline) {
-            bookingRepository.syncPendingCancellations(() ->
-                    loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED"));
+            // Leer el snapshot de Room ANTES de encolar el WorkManager para evitar la race condition
+            // donde el worker borra la fila de pendingCancel antes de que loadHistorial pueda leerla.
+            bookingRepository.loadCachedPendingCancellations(new RepositoryCallback<List<BookingResponse>>() {
+                @Override
+                public void onSuccess(List<BookingResponse> snapshot) {
+                    reconnectPendingSnapshot = snapshot != null ? snapshot : Collections.emptyList();
+                    enqueueSyncWorker();
+                    loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
+                    historialLoaded = false;
+                    if (selectedTab == 1) loadHistorial();
+                }
+                @Override
+                public void onError(UiMessage e) {
+                    reconnectPendingSnapshot = Collections.emptyList();
+                    enqueueSyncWorker();
+                    loadMyBookings(currentFilter != null ? currentFilter : "CONFIRMED");
+                    historialLoaded = false;
+                    if (selectedTab == 1) loadHistorial();
+                }
+            });
         } else {
             loadCachedBookings();
         }
     }
 
+    private void enqueueSyncWorker() {
+        OneTimeWorkRequest syncWork = new OneTimeWorkRequest.Builder(SyncCancellationsWorker.class)
+                .setConstraints(new Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build())
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL,
+                        OneTimeWorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+                .build();
+        WorkManager.getInstance(context).enqueueUniqueWork(
+                "sync_cancellations", ExistingWorkPolicy.KEEP, syncWork);
+    }
+
     public void loadMyBookings(String statusFilter) {
         currentFilter = statusFilter;
+        // Capturar IDs actuales antes del refresh para detectar cancelaciones del servidor (O17)
+        final Set<Long> prevIds = new HashSet<>();
+        if ("CONFIRMED".equals(statusFilter)) {
+            List<BookingResponse> cur = _bookings.getValue();
+            if (cur != null) {
+                for (BookingResponse b : cur) { if (b.id != null) prevIds.add(b.id); }
+            }
+        }
         _loading.setValue(true);
 
         if (offline) {
@@ -108,7 +156,16 @@ public class BookingsViewModel extends ViewModel {
             @Override
             public void onSuccess(List<BookingResponse> data) {
                 _loading.setValue(false);
-                _bookings.setValue(data != null ? data : Collections.emptyList());
+                List<BookingResponse> fresh = data != null ? data : Collections.emptyList();
+                if (!prevIds.isEmpty()) {
+                    Set<Long> newIds = new HashSet<>();
+                    for (BookingResponse b : fresh) { if (b.id != null) newIds.add(b.id); }
+                    prevIds.removeAll(newIds);
+                    if (!prevIds.isEmpty()) {
+                        _message.setValue(UiMessage.from(R.string.booking_cancelled_by_server));
+                    }
+                }
+                _bookings.setValue(fresh);
             }
 
             @Override
@@ -138,8 +195,12 @@ public class BookingsViewModel extends ViewModel {
         if (bookingId == null) return;
 
         if (offline) {
-            bookingRepository.cancelBookingLocally(bookingId,
-                    () -> loadMyBookings(currentFilter));
+            bookingRepository.cancelBookingLocally(bookingId, () -> {
+                _message.setValue(UiMessage.from(R.string.cancel_booking_offline_queued));
+                loadMyBookings(currentFilter);
+                historialLoaded = false;
+                if (selectedTab == 1) loadHistorial();
+            });
             return;
         }
 
@@ -149,6 +210,8 @@ public class BookingsViewModel extends ViewModel {
             public void onSuccess(BookingResponse data) {
                 _loading.setValue(false);
                 loadMyBookings(currentFilter);
+                historialLoaded = false;
+                if (selectedTab == 1) loadHistorial();
             }
 
             @Override
@@ -168,11 +231,62 @@ public class BookingsViewModel extends ViewModel {
 
     public void loadHistorial() {
         _historialLoading.setValue(true);
+        if (reconnectPendingSnapshot != null) {
+            List<BookingResponse> snapshot = reconnectPendingSnapshot;
+            reconnectPendingSnapshot = null;
+            fetchHistorialWithPending(snapshot);
+            return;
+        }
+        bookingRepository.loadCachedPendingCancellations(new RepositoryCallback<List<BookingResponse>>() {
+            @Override
+            public void onSuccess(List<BookingResponse> pending) {
+                fetchHistorialWithPending(pending);
+            }
+            @Override
+            public void onError(UiMessage e) {
+                fetchHistorialWithPending(null);
+            }
+        });
+    }
+
+    // pending == null indica fallo de DB: se omite el merge y se usa solo el servidor.
+    private void fetchHistorialWithPending(List<BookingResponse> pending) {
+        List<BookingSummaryItem> pendingItems = new ArrayList<>();
+        Set<Long> pendingIds = new java.util.HashSet<>();
+        if (pending != null) {
+            for (BookingResponse p : pending) {
+                BookingSummaryItem item = toSummaryItem(p);
+                pendingItems.add(item);
+                if (p.id != null) pendingIds.add(p.id);
+            }
+        }
+
+        // Sin red: usar datos locales directamente sin esperar timeout de red
+        if (offline) {
+            historialLoaded = true;
+            List<BookingSummaryItem> all = new ArrayList<>(pendingItems);
+            for (BookingSummaryItem cached : cachedServerHistorialItems) {
+                if (cached.getId() == null || !pendingIds.contains(cached.getId())) all.add(cached);
+            }
+            allHistorialItems = all;
+            updateDestinationSuggestions();
+            applyFilters();
+            _historialLoading.setValue(false);
+            return;
+        }
+
         profileRepository.getActivitySummary(new RepositoryCallback<List<BookingSummaryItem>>() {
             @Override
             public void onSuccess(List<BookingSummaryItem> data) {
+                List<BookingSummaryItem> serverItems = data != null ? data : Collections.emptyList();
+                cachedServerHistorialItems = serverItems;
                 historialLoaded = true;
-                allHistorialItems = data != null ? data : Collections.emptyList();
+                List<BookingSummaryItem> all = new ArrayList<>();
+                for (BookingSummaryItem p : pendingItems) {
+                    if (p.getId() == null || !containsId(serverItems, p.getId())) all.add(p);
+                }
+                all.addAll(serverItems);
+                allHistorialItems = all;
                 updateDestinationSuggestions();
                 applyFilters();
                 _historialLoading.setValue(false);
@@ -181,12 +295,43 @@ public class BookingsViewModel extends ViewModel {
             @Override
             public void onError(UiMessage error) {
                 historialLoaded = true;
-                allHistorialItems = Collections.emptyList();
-                _historial.setValue(Collections.emptyList());
-                _error.setValue(error);
+                List<BookingSummaryItem> all = new ArrayList<>();
+                if (pending == null) {
+                    // DB también falló: usar solo caché del servidor anterior
+                    all.addAll(cachedServerHistorialItems);
+                } else {
+                    all.addAll(pendingItems);
+                    for (BookingSummaryItem cached : cachedServerHistorialItems) {
+                        if (cached.getId() == null || !pendingIds.contains(cached.getId())) all.add(cached);
+                    }
+                    updateDestinationSuggestions();
+                }
+                allHistorialItems = all;
+                applyFilters();
                 _historialLoading.setValue(false);
+                if (all.isEmpty()) _error.setValue(error);
             }
         });
+    }
+
+    private static boolean containsId(List<BookingSummaryItem> items, Long id) {
+        for (BookingSummaryItem item : items) {
+            if (id.equals(item.getId())) return true;
+        }
+        return false;
+    }
+
+    private BookingSummaryItem toSummaryItem(BookingResponse b) {
+        String date = "";
+        String time = "";
+        if (b.sessionStartTime != null && b.sessionStartTime.length() >= 10) {
+            date = b.sessionStartTime.substring(0, 10);
+            if (b.sessionStartTime.length() >= 16) time = b.sessionStartTime.substring(11, 16);
+        }
+        String price = b.currency != null ? b.totalPrice + " " + b.currency : "";
+        String destination = b.destination != null ? b.destination.name : "";
+        return new BookingSummaryItem(b.id, b.activityId, b.activityName,
+                b.status, date, price, destination, b.guideName, b.durationMinutes, null, time);
     }
 
     public void setFilterDestination(String destination) {

--- a/app/src/main/java/com/example/myapplication/ui/home/DetailFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/DetailFragment.java
@@ -1,5 +1,8 @@
 package com.example.myapplication.ui.home;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -138,15 +141,21 @@ public class DetailFragment extends Fragment {
         });
         createBookingViewModel.getBooking().observe(getViewLifecycleOwner(), booking -> {
             if (booking != null) {
-                android.widget.Toast.makeText(requireContext(), "Reserva creada", android.widget.Toast.LENGTH_SHORT).show();
-                // refresca cupos/sesiones
-                if (tourActivity != null && tourActivity.getId() != null) {
-                    detailViewModel.load(tourActivity.getId());
-                }
-                // ocultar card hasta una nueva seleccion (updateData resetea la seleccion)
                 selectedSession = null;
                 if (bookingCard != null) bookingCard.setVisibility(View.GONE);
                 createBookingViewModel.clearBooking();
+                if (booking.id != null && booking.id > 0) {
+                    Bundle voucherArgs = new Bundle();
+                    voucherArgs.putLong("bookingId", booking.id);
+                    androidx.navigation.Navigation.findNavController(requireView())
+                            .navigate(R.id.action_detailFragment_to_voucherFragment, voucherArgs);
+                } else {
+                    android.widget.Toast.makeText(requireContext(),
+                            getString(R.string.voucher_confirmed), android.widget.Toast.LENGTH_SHORT).show();
+                    if (tourActivity != null && tourActivity.getId() != null) {
+                        detailViewModel.load(tourActivity.getId());
+                    }
+                }
             }
         });
 
@@ -219,7 +228,16 @@ public class DetailFragment extends Fragment {
                     sessionsRecycler.setVisibility(hasSessions ? View.VISIBLE : View.GONE);
                 });
 
-                detailViewModel.load(id);
+                if (isOnline()) {
+                    detailViewModel.load(id);
+                } else {
+                    if (loading != null) loading.setVisibility(View.GONE);
+                    if (sessionsTitle != null) sessionsTitle.setVisibility(View.GONE);
+                    sessionsRecycler.setVisibility(View.GONE);
+                    if (bookingCard != null) bookingCard.setVisibility(View.GONE);
+                    android.widget.Toast.makeText(requireContext(),
+                            "Sin conexión. Mostrando datos guardados.", android.widget.Toast.LENGTH_SHORT).show();
+                }
             } else {
                 if (sessionsTitle != null) sessionsTitle.setVisibility(View.GONE);
                 sessionsRecycler.setVisibility(View.GONE);
@@ -334,6 +352,16 @@ public class DetailFragment extends Fragment {
                 }
             }
         }
+    }
+
+    private boolean isOnline() {
+        ConnectivityManager cm = (ConnectivityManager) requireContext()
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        android.net.Network network = cm.getActiveNetwork();
+        if (network == null) return false;
+        NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+        return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/ui/home/DetailFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/DetailFragment.java
@@ -228,6 +228,14 @@ public class DetailFragment extends Fragment {
                     sessionsRecycler.setVisibility(hasSessions ? View.VISIBLE : View.GONE);
                 });
 
+                detailViewModel.isOfflineCacheMiss().observe(getViewLifecycleOwner(), miss -> {
+                    if (Boolean.TRUE.equals(miss)) {
+                        android.widget.Toast.makeText(requireContext(),
+                                getString(R.string.detail_offline_cache_miss),
+                                android.widget.Toast.LENGTH_LONG).show();
+                    }
+                });
+
                 if (isOnline()) {
                     detailViewModel.load(id);
                 } else {
@@ -235,6 +243,7 @@ public class DetailFragment extends Fragment {
                     if (sessionsTitle != null) sessionsTitle.setVisibility(View.GONE);
                     sessionsRecycler.setVisibility(View.GONE);
                     if (bookingCard != null) bookingCard.setVisibility(View.GONE);
+                    detailViewModel.loadFromCache(id);
                     android.widget.Toast.makeText(requireContext(),
                             "Sin conexión. Mostrando datos guardados.", android.widget.Toast.LENGTH_SHORT).show();
                 }
@@ -259,7 +268,7 @@ public class DetailFragment extends Fragment {
         TextView duration = root.findViewById(R.id.activity_duration);
         TextView price = root.findViewById(R.id.activity_price);
         TextView slots = root.findViewById(R.id.activity_slots);
-        
+
         View detailedContainer = root.findViewById(R.id.detailed_info_container);
         TextView description = root.findViewById(R.id.activity_description);
         TextView rating = root.findViewById(R.id.activity_rating);
@@ -270,21 +279,21 @@ public class DetailFragment extends Fragment {
         TextView cancellation = root.findViewById(R.id.activity_cancellation);
         com.google.android.material.floatingactionbutton.FloatingActionButton favoriteButton = root.findViewById(R.id.favorite_button);
 
-        // Forzar visibilidad del contenedor de detalles
         if (detailedContainer != null) {
             detailedContainer.setVisibility(View.VISIBLE);
         }
 
-        name.setText(tourActivity.getName());
-        destination.setText(tourActivity.getDestination());
-        category.setText(tourActivity.getCategory().toUpperCase());
-        duration.setText(tourActivity.getDuration());
-        price.setText(tourActivity.getPrice());
+        name.setText(nd(tourActivity.getName()));
+        destination.setText(nd(tourActivity.getDestination()));
+        String cat = tourActivity.getCategory();
+        category.setText(cat != null && !cat.isEmpty() ? cat.toUpperCase() : getString(R.string.no_data));
+        duration.setText(nd(tourActivity.getDuration()));
+        price.setText(nd(tourActivity.getPrice()));
         boolean soldOut = tourActivity.getAvailableSlots() <= 0;
         slots.setText(soldOut
                 ? getString(R.string.sold_out)
                 : getString(R.string.slots_available, tourActivity.getAvailableSlots()));
-        root.setAlpha(soldOut ? 0.65f : 1f);
+        root.setAlpha((!fromHistory && soldOut) ? 0.65f : 1f);
         slots.setVisibility(fromHistory ? View.GONE : View.VISIBLE);
 
         if (favoriteButton != null) {
@@ -304,7 +313,7 @@ public class DetailFragment extends Fragment {
             });
         }
 
-        if (description != null) description.setText(tourActivity.getDescription());
+        if (description != null) description.setText(nd(tourActivity.getDescription()));
         if (rating != null) {
             if (tourActivity.getReviewsCount() <= 0) {
                 rating.setText(getString(R.string.no_reviews));
@@ -312,11 +321,11 @@ public class DetailFragment extends Fragment {
                 rating.setText(String.valueOf(tourActivity.getRating()));
             }
         }
-        if (language != null) language.setText("Idioma: " + tourActivity.getLanguage());
-        if (guide != null) guide.setText("Guía: " + tourActivity.getGuideName());
-        if (meetingPoint != null) meetingPoint.setText("Encuentro: " + tourActivity.getMeetingPoint());
-        if (includes != null) includes.setText(tourActivity.getWhatIncluded());
-        if (cancellation != null) cancellation.setText(tourActivity.getCancellationPolicy());
+        if (language != null) language.setText("Idioma: " + nd(tourActivity.getLanguage()));
+        if (guide != null) guide.setText("Guía: " + nd(tourActivity.getGuideName()));
+        if (meetingPoint != null) meetingPoint.setText("Encuentro: " + nd(tourActivity.getMeetingPoint()));
+        if (includes != null) includes.setText(nd(tourActivity.getWhatIncluded()));
+        if (cancellation != null) cancellation.setText(nd(tourActivity.getCancellationPolicy()));
 
         if (image != null) {
             // Ajustar altura de imagen para detalle (opcional, como tenías en tu Activity)
@@ -351,6 +360,25 @@ public class DetailFragment extends Fragment {
                     commentView.setVisibility(View.GONE);
                 }
             }
+        }
+    }
+
+    /** Campos requeridos: siempre muestran "No disponible" si están vacíos. */
+    private String nd(String value) {
+        return (value != null && !value.trim().isEmpty()) ? value : getString(R.string.no_data);
+    }
+
+    /**
+     * Campos opcionales: visibles con su texto cuando hay dato, ocultos cuando no.
+     * @param prefix prefijo a mostrar antes del valor (ej. "Idioma: "), o null si no hay.
+     */
+    private void setOptionalText(TextView view, String value, String prefix) {
+        if (view == null) return;
+        if (value != null && !value.trim().isEmpty()) {
+            view.setText(prefix != null ? prefix + value : value);
+            view.setVisibility(View.VISIBLE);
+        } else {
+            view.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/ui/home/viewmodel/DetailViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/viewmodel/DetailViewModel.java
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel;
 import com.example.myapplication.R;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
+import com.example.myapplication.data.local.CachedActivityDao;
+import com.example.myapplication.data.local.CachedActivityEntity;
 import com.example.myapplication.data.model.ActivityDetailResponse;
 import com.example.myapplication.data.model.ActivitySessionResponse;
 import com.example.myapplication.data.model.TourActivity;
@@ -14,6 +16,8 @@ import com.example.myapplication.util.FormatUtils;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 
 @HiltViewModel
@@ -24,22 +28,27 @@ public class DetailViewModel extends ViewModel {
     }
 
     private final TourRepository tourRepository;
+    private final CachedActivityDao cachedActivityDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     private final MutableLiveData<TourActivity> _activity = new MutableLiveData<>();
     private final MutableLiveData<List<ActivitySessionResponse>> _sessions =
             new MutableLiveData<>(Collections.emptyList());
     private final MutableLiveData<UiMessage> _error = new MutableLiveData<>();
     private final MutableLiveData<Boolean> _loading = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> _offlineCacheMiss = new MutableLiveData<>();
 
     @Inject
-    public DetailViewModel(TourRepository tourRepository) {
+    public DetailViewModel(TourRepository tourRepository, CachedActivityDao cachedActivityDao) {
         this.tourRepository = tourRepository;
+        this.cachedActivityDao = cachedActivityDao;
     }
 
     public LiveData<TourActivity> getActivity() { return _activity; }
     public LiveData<List<ActivitySessionResponse>> getSessions() { return _sessions; }
     public LiveData<UiMessage> getError() { return _error; }
     public LiveData<Boolean> isLoading() { return _loading; }
+    public LiveData<Boolean> isOfflineCacheMiss() { return _offlineCacheMiss; }
 
     public void toggleFavorite(long activityId, boolean targetFavorite, FavoriteToggleCallback callback) {
         tourRepository.toggleFavorite(activityId, targetFavorite, new RepositoryCallback<Void>() {
@@ -61,7 +70,20 @@ public class DetailViewModel extends ViewModel {
         });
     }
 
+    public void loadFromCache(long activityId) {
+        _offlineCacheMiss.setValue(null);
+        dbExecutor.execute(() -> {
+            CachedActivityEntity entity = cachedActivityDao.getById(activityId);
+            if (entity != null) {
+                _activity.postValue(TourRepository.mapFromCache(entity));
+            } else {
+                _offlineCacheMiss.postValue(true);
+            }
+        });
+    }
+
     public void load(long activityId) {
+        _offlineCacheMiss.setValue(null);
         _loading.setValue(true);
         tourRepository.getActivityDetail(activityId, new RepositoryCallback<ActivityDetailResponse>() {
             @Override

--- a/app/src/main/java/com/example/myapplication/ui/home/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/viewmodel/HomeViewModel.java
@@ -5,12 +5,15 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
+import com.example.myapplication.data.local.CachedActivityDao;
+import com.example.myapplication.data.local.CachedActivityEntity;
 import com.example.myapplication.data.local.OfflineBookingDao;
 import com.example.myapplication.data.local.ProfileImageManager;
 import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.data.repository.SessionRepository;
 import com.example.myapplication.data.repository.TourRepository;
 import dagger.hilt.android.lifecycle.HiltViewModel;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -27,6 +30,7 @@ public class HomeViewModel extends ViewModel {
     private final TourRepository tourRepository;
     private final ProfileImageManager profileImageManager;
     private final OfflineBookingDao offlineBookingDao;
+    private final CachedActivityDao cachedActivityDao;
     private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     private final MutableLiveData<List<TourActivity>> _featuredTours = new MutableLiveData<>();
@@ -37,11 +41,13 @@ public class HomeViewModel extends ViewModel {
 
     @Inject
     public HomeViewModel(SessionRepository sessionRepository, TourRepository tourRepository,
-                         ProfileImageManager profileImageManager, OfflineBookingDao offlineBookingDao) {
+                         ProfileImageManager profileImageManager, OfflineBookingDao offlineBookingDao,
+                         CachedActivityDao cachedActivityDao) {
         this.sessionRepository = sessionRepository;
         this.tourRepository = tourRepository;
         this.profileImageManager = profileImageManager;
         this.offlineBookingDao = offlineBookingDao;
+        this.cachedActivityDao = cachedActivityDao;
         refreshTours();
     }
 
@@ -101,8 +107,19 @@ public class HomeViewModel extends ViewModel {
 
             @Override
             public void onError(UiMessage error) {
-                _error.setValue(error);
+                loadAllToursFromCache();
                 onCallFinished();
+            }
+        });
+    }
+
+    private void loadAllToursFromCache() {
+        dbExecutor.execute(() -> {
+            List<CachedActivityEntity> cached = cachedActivityDao.getAll();
+            if (cached != null && !cached.isEmpty()) {
+                List<TourActivity> result = new ArrayList<>(cached.size());
+                for (CachedActivityEntity e : cached) result.add(TourRepository.mapFromCache(e));
+                _allTours.postValue(result);
             }
         });
     }

--- a/app/src/main/java/com/example/myapplication/ui/home/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/viewmodel/HomeViewModel.java
@@ -5,12 +5,15 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
+import com.example.myapplication.data.local.OfflineBookingDao;
 import com.example.myapplication.data.local.ProfileImageManager;
 import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.data.repository.SessionRepository;
 import com.example.myapplication.data.repository.TourRepository;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Inject;
 
 @HiltViewModel
@@ -23,6 +26,8 @@ public class HomeViewModel extends ViewModel {
     private final SessionRepository sessionRepository;
     private final TourRepository tourRepository;
     private final ProfileImageManager profileImageManager;
+    private final OfflineBookingDao offlineBookingDao;
+    private final Executor dbExecutor = Executors.newSingleThreadExecutor();
 
     private final MutableLiveData<List<TourActivity>> _featuredTours = new MutableLiveData<>();
     private final MutableLiveData<List<TourActivity>> _allTours = new MutableLiveData<>();
@@ -32,10 +37,11 @@ public class HomeViewModel extends ViewModel {
 
     @Inject
     public HomeViewModel(SessionRepository sessionRepository, TourRepository tourRepository,
-                         ProfileImageManager profileImageManager) {
+                         ProfileImageManager profileImageManager, OfflineBookingDao offlineBookingDao) {
         this.sessionRepository = sessionRepository;
         this.tourRepository = tourRepository;
         this.profileImageManager = profileImageManager;
+        this.offlineBookingDao = offlineBookingDao;
         refreshTours();
     }
 
@@ -49,8 +55,10 @@ public class HomeViewModel extends ViewModel {
     }
 
     public void logout() {
-        profileImageManager.delete(sessionRepository.getUserId());
+        long userId = sessionRepository.getUserId();
+        profileImageManager.delete(userId);
         sessionRepository.clearSession();
+        dbExecutor.execute(() -> offlineBookingDao.deleteAllByUser(userId));
     }
 
     public void reloadRecommended() {

--- a/app/src/main/java/com/example/myapplication/ui/main/MainViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/main/MainViewModel.java
@@ -1,0 +1,67 @@
+package com.example.myapplication.ui.main;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
+import androidx.lifecycle.ViewModel;
+import com.example.myapplication.data.common.RepositoryCallback;
+import com.example.myapplication.data.common.UiMessage;
+import com.example.myapplication.data.model.BookingResponse;
+import com.example.myapplication.data.model.BookingSummaryItem;
+import com.example.myapplication.data.repository.BookingRepository;
+import com.example.myapplication.data.repository.ProfileRepository;
+import com.example.myapplication.data.repository.SessionRepository;
+import dagger.hilt.android.lifecycle.HiltViewModel;
+import dagger.hilt.android.qualifiers.ApplicationContext;
+import java.util.List;
+import javax.inject.Inject;
+
+@HiltViewModel
+public class MainViewModel extends ViewModel {
+
+    private final BookingRepository bookingRepository;
+    private final ProfileRepository profileRepository;
+
+    @Inject
+    public MainViewModel(BookingRepository bookingRepository,
+                         ProfileRepository profileRepository,
+                         SessionRepository sessionRepository,
+                         @ApplicationContext Context context) {
+        this.bookingRepository = bookingRepository;
+        this.profileRepository = profileRepository;
+
+        if (sessionRepository.hasValidSession() && isOnline(context)) {
+            syncBookings();
+            syncHistorial();
+        }
+    }
+
+    private void syncBookings() {
+        bookingRepository.listMyBookings("CONFIRMED", new RepositoryCallback<List<BookingResponse>>() {
+            @Override public void onSuccess(List<BookingResponse> data) {}
+            @Override public void onError(UiMessage e) {}
+        });
+    }
+
+    private void syncHistorial() {
+        profileRepository.getActivitySummary(new RepositoryCallback<List<BookingSummaryItem>>() {
+            @Override public void onSuccess(List<BookingSummaryItem> data) {}
+            @Override public void onError(UiMessage e) {}
+        });
+    }
+
+    private boolean isOnline(Context context) {
+        ConnectivityManager cm = (ConnectivityManager)
+                context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        NetworkCapabilities caps = cm.getNetworkCapabilities(cm.getActiveNetwork());
+        return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+    }
+
+    @Override
+    protected void onCleared() {
+        bookingRepository.cancelAll();
+        profileRepository.cancelAll();
+        super.onCleared();
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/main/MainViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/main/MainViewModel.java
@@ -1,16 +1,17 @@
 package com.example.myapplication.ui.main;
 
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkCapabilities;
 import androidx.lifecycle.ViewModel;
 import com.example.myapplication.data.common.RepositoryCallback;
 import com.example.myapplication.data.common.UiMessage;
 import com.example.myapplication.data.model.BookingResponse;
 import com.example.myapplication.data.model.BookingSummaryItem;
+import com.example.myapplication.data.model.TourActivity;
 import com.example.myapplication.data.repository.BookingRepository;
 import com.example.myapplication.data.repository.ProfileRepository;
 import com.example.myapplication.data.repository.SessionRepository;
+import com.example.myapplication.data.repository.TourRepository;
+import com.example.myapplication.util.ConnectivityUtils;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import java.util.List;
@@ -21,18 +22,22 @@ public class MainViewModel extends ViewModel {
 
     private final BookingRepository bookingRepository;
     private final ProfileRepository profileRepository;
+    private final TourRepository tourRepository;
 
     @Inject
     public MainViewModel(BookingRepository bookingRepository,
                          ProfileRepository profileRepository,
                          SessionRepository sessionRepository,
+                         TourRepository tourRepository,
                          @ApplicationContext Context context) {
         this.bookingRepository = bookingRepository;
         this.profileRepository = profileRepository;
+        this.tourRepository = tourRepository;
 
-        if (sessionRepository.hasValidSession() && isOnline(context)) {
+        if (sessionRepository.hasValidSession() && ConnectivityUtils.isOnline(context)) {
             syncBookings();
             syncHistorial();
+            syncActivities();
         }
     }
 
@@ -50,18 +55,18 @@ public class MainViewModel extends ViewModel {
         });
     }
 
-    private boolean isOnline(Context context) {
-        ConnectivityManager cm = (ConnectivityManager)
-                context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (cm == null) return false;
-        NetworkCapabilities caps = cm.getNetworkCapabilities(cm.getActiveNetwork());
-        return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+    private void syncActivities() {
+        tourRepository.getAllTours(new RepositoryCallback<List<TourActivity>>() {
+            @Override public void onSuccess(List<TourActivity> data) {}
+            @Override public void onError(UiMessage e) {}
+        });
     }
 
     @Override
     protected void onCleared() {
         bookingRepository.cancelAll();
         profileRepository.cancelAll();
+        tourRepository.cancelAll();
         super.onCleared();
     }
 }

--- a/app/src/main/java/com/example/myapplication/ui/profile/ActivitySummaryAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/profile/ActivitySummaryAdapter.java
@@ -45,6 +45,7 @@ public class ActivitySummaryAdapter extends RecyclerView.Adapter<ActivitySummary
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         BookingSummaryItem item = items.get(position);
         holder.name.setText(item.getActivityName());
+        bindStatusBadge(holder.statusBadge, item.getStatus());
         holder.date.setText(item.getDate());
         holder.destination.setText(item.getDestination());
         holder.duration.setText(FormatUtils.formatDuration(item.getDurationMinutes()));
@@ -78,9 +79,39 @@ public class ActivitySummaryAdapter extends RecyclerView.Adapter<ActivitySummary
         return items.size();
     }
 
+    private static void bindStatusBadge(TextView badge, String status) {
+        if (status == null) { badge.setVisibility(View.GONE); return; }
+        android.content.Context ctx = badge.getContext();
+        String label;
+        int bgColor, textColor;
+        switch (status.toUpperCase()) {
+            case "CONFIRMED":
+                label = ctx.getString(R.string.status_confirmed);
+                bgColor = 0xFFE3F2FD; textColor = 0xFF1565C0; break;
+            case "COMPLETED":
+                label = ctx.getString(R.string.status_completed);
+                bgColor = 0xFFE8F5E9; textColor = 0xFF2E7D32; break;
+            case "CANCELLED":
+                label = ctx.getString(R.string.status_cancelled);
+                bgColor = 0xFFFFEBEE; textColor = 0xFFB71C1C; break;
+            case "PENDING":
+                label = ctx.getString(R.string.status_pending);
+                bgColor = 0xFFFFF8E1; textColor = 0xFFE65100; break;
+            case "PENDING_CANCEL":
+                label = ctx.getString(R.string.status_pending_cancel);
+                bgColor = 0xFFFFF3E0; textColor = 0xFFBF360C; break;
+            default:
+                label = status; bgColor = 0xFFF5F5F5; textColor = 0xFF616161; break;
+        }
+        badge.setText(label);
+        badge.setBackgroundTintList(android.content.res.ColorStateList.valueOf(bgColor));
+        badge.setTextColor(textColor);
+        badge.setVisibility(View.VISIBLE);
+    }
+
     static class ViewHolder extends RecyclerView.ViewHolder {
         ImageView image;
-        TextView name, date, destination, guide, duration;
+        TextView name, date, destination, guide, duration, statusBadge;
         View guideRow;
         MaterialButton detailButton;
 
@@ -88,6 +119,7 @@ public class ActivitySummaryAdapter extends RecyclerView.Adapter<ActivitySummary
             super(itemView);
             image        = itemView.findViewById(R.id.summary_image);
             name         = itemView.findViewById(R.id.summary_activity_name);
+            statusBadge  = itemView.findViewById(R.id.summary_status_badge);
             date         = itemView.findViewById(R.id.summary_date);
             destination  = itemView.findViewById(R.id.summary_destination);
             guide        = itemView.findViewById(R.id.summary_guide);

--- a/app/src/main/java/com/example/myapplication/util/ConnectivityUtils.java
+++ b/app/src/main/java/com/example/myapplication/util/ConnectivityUtils.java
@@ -1,0 +1,18 @@
+package com.example.myapplication.util;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
+
+public final class ConnectivityUtils {
+
+    private ConnectivityUtils() {}
+
+    public static boolean isOnline(Context context) {
+        ConnectivityManager cm = (ConnectivityManager)
+                context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        NetworkCapabilities caps = cm.getNetworkCapabilities(cm.getActiveNetwork());
+        return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+    }
+}

--- a/app/src/main/java/com/example/myapplication/util/FormatUtils.java
+++ b/app/src/main/java/com/example/myapplication/util/FormatUtils.java
@@ -44,4 +44,11 @@ public final class FormatUtils {
         if (iso == null || iso.length() < 10) return iso != null ? iso : "";
         return iso.substring(0, 10);
     }
+
+    /** Extrae solo la hora "HH:mm" de un ISO timestamp. */
+    public static String extractTime(String iso) {
+        if (iso == null) return "";
+        String s = formatStartTime(iso);
+        return s.length() >= 16 ? s.substring(11, 16) : "";
+    }
 }

--- a/app/src/main/java/com/example/myapplication/util/MainThreadUtils.java
+++ b/app/src/main/java/com/example/myapplication/util/MainThreadUtils.java
@@ -1,0 +1,15 @@
+package com.example.myapplication.util;
+
+import android.os.Handler;
+import android.os.Looper;
+
+public final class MainThreadUtils {
+
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
+
+    private MainThreadUtils() {}
+
+    public static void post(Runnable action) {
+        MAIN_HANDLER.post(action);
+    }
+}

--- a/app/src/main/res/drawable/bg_voucher_code.xml
+++ b/app/src/main/res/drawable/bg_voucher_code.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="2dp"
+        android:color="#7C3AED"
+        android:dashWidth="8dp"
+        android:dashGap="4dp" />
+    <corners android:radius="12dp" />
+    <solid android:color="#F5F0FF" />
+</shape>

--- a/app/src/main/res/drawable/ic_check_circle.xml
+++ b/app/src/main/res/drawable/ic_check_circle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4CAF50"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z" />
+</vector>

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,9H15V3H9V9H5L12,16L19,9ZM5,18V20H19V18H5Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_money.xml
+++ b/app/src/main/res/drawable/ic_money.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11.8,10.9C9.53,10.31 8.8,9.7 8.8,8.75C8.8,7.66 9.81,6.9 11.5,6.9C13.28,6.9 13.94,7.75 14,9H16.21C16.14,7.28 15.09,5.7 13,5.19V3H10V5.16C8.06,5.58 6.5,6.84 6.5,8.77C6.5,11.08 8.41,12.23 11.2,12.9C13.7,13.5 14.2,14.38 14.2,15.31C14.2,16 13.71,17.1 11.5,17.1C9.44,17.1 8.63,16.18 8.52,15H6.32C6.44,17.19 8.08,18.42 10,18.83V21H13V18.85C14.95,18.48 16.5,17.35 16.5,15.3C16.5,12.46 14.07,11.49 11.8,10.9Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shield.xml
+++ b/app/src/main/res/drawable/ic_shield.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1ZM19,11C19,15.52 16.02,19.69 12,21C7.98,19.69 5,15.52 5,11V6.3L12,3.19L19,6.3V11Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_ticket.xml
+++ b/app/src/main/res/drawable/ic_ticket.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,12C20,11.45 20.45,11 21,11V7C21,5.9 20.1,5 19,5H5C3.9,5 3,5.9 3,7V11C3.55,11 4,11.45 4,12C4,12.55 3.55,13 3,13V17C3,18.1 3.9,19 5,19H19C20.1,19 21,18.1 21,17V13C20.45,13 20,12.55 20,12ZM19,17H5V14.54C5.76,14.23 6.32,13.57 6.32,12.75C6.32,11.75 5.57,11 5,10.54V7H19V10.54C18.43,11 17.68,11.75 17.68,12.75C17.68,13.57 18.24,14.23 19,14.54V17Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_bookings.xml
+++ b/app/src/main/res/layout/fragment_bookings.xml
@@ -69,14 +69,21 @@
             android:layout_height="match_parent"
             android:visibility="visible">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/bookings_recycler_view"
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/swipe_refresh"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingTop="8dp"
-                android:paddingBottom="24dp"
-                android:clipToPadding="false"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+                android:layout_height="match_parent">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/bookings_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="24dp"
+                    android:clipToPadding="false"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
             <ProgressBar
                 android:id="@+id/bookings_loading_spinner"
@@ -92,7 +99,6 @@
                 android:layout_gravity="top"
                 android:layout_marginTop="32dp"
                 android:gravity="center"
-                android:text="@string/bookings_empty_activas"
                 android:textAppearance="@style/TextAppearance.XploreNow.Body"
                 android:textColor="?attr/colorOnSurfaceVariant"
                 android:visibility="gone" />

--- a/app/src/main/res/layout/fragment_voucher.xml
+++ b/app/src/main/res/layout/fragment_voucher.xml
@@ -1,0 +1,482 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="?attr/colorSurface">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/voucher_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:navigationIcon="@drawable/ic_back"
+            app:title="@string/voucher_title"
+            app:titleTextColor="?attr/colorOnSurface" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <!-- ── Banner confirmado ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:background="#E8F5E9"
+                android:padding="14dp"
+                android:layout_marginBottom="20dp">
+
+                <ImageView
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@drawable/ic_check_circle"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_confirmed"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:textColor="#1B5E20" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_confirmed_subtitle"
+                        android:textSize="13sp"
+                        android:textColor="#388E3C" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Nombre actividad ── -->
+            <TextView
+                android:id="@+id/voucher_activity_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                android:textColor="?attr/colorOnSurface"
+                android:layout_marginBottom="6dp" />
+
+            <!-- ── Destino ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="20dp">
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_location"
+                    app:tint="?attr/colorOnSurfaceVariant"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:id="@+id/voucher_destination"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textSize="14sp"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorOutlineVariant"
+                android:layout_marginBottom="20dp" />
+
+            <!-- ── Fecha y hora ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="16dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_calendar"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_datetime"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_datetime"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Punto de encuentro ── -->
+            <LinearLayout
+                android:id="@+id/voucher_meeting_point_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_location"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_meeting_point"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_meeting_point"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Duración ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="16dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_clock"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_duration"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_duration"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Guía ── -->
+            <LinearLayout
+                android:id="@+id/voucher_guide_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_person"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_guide"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_guide"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Participantes ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="16dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_person"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_participants"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_participants"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- ── Precio ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="20dp">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_money"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_label_price"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:id="@+id/voucher_price"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorOnSurface" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorOutlineVariant"
+                android:layout_marginBottom="20dp" />
+
+            <!-- ── Label código ── -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/voucher_code_label"
+                android:textSize="11sp"
+                android:textAllCaps="true"
+                android:letterSpacing="0.1"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:layout_marginBottom="10dp" />
+
+            <!-- ── Caja del código (borde punteado) ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:background="@drawable/bg_voucher_code"
+                android:padding="20dp"
+                android:layout_marginBottom="12dp">
+
+                <ImageView
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@drawable/ic_ticket"
+                    app:tint="?attr/colorPrimary"
+                    android:layout_marginBottom="8dp"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:id="@+id/voucher_code"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="22sp"
+                    android:textStyle="bold"
+                    android:letterSpacing="0.08"
+                    android:textColor="?attr/colorPrimary"
+                    android:layout_marginBottom="6dp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/voucher_code_hint"
+                    android:textSize="12sp"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:gravity="center" />
+
+            </LinearLayout>
+
+            <!-- ── Caja "Guardá este código" ── -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:background="#F5F0FF"
+                android:padding="14dp"
+                android:layout_marginBottom="24dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_shield"
+                    app:tint="?attr/colorPrimary"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_save_title"
+                        android:textSize="13sp"
+                        android:textStyle="bold"
+                        android:textColor="?attr/colorPrimary" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_save_subtitle"
+                        android:textSize="12sp"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+    <!-- ── Botón Descargar voucher ── -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/voucher_download_button"
+        style="@style/Widget.Material3.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/voucher_download_button"
+        android:textSize="15sp"
+        app:icon="@drawable/ic_download"
+        app:iconGravity="textStart" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_activity_summary.xml
+++ b/app/src/main/res/layout/item_activity_summary.xml
@@ -42,6 +42,20 @@
                 android:textAppearance="@style/TextAppearance.XploreNow.H2"
                 android:textStyle="bold" />
 
+            <!-- Status badge -->
+            <TextView
+                android:id="@+id/summary_status_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:background="@drawable/bg_badge_upcoming"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="3dp"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
             <!-- Destination -->
             <TextView
                 android:id="@+id/summary_destination"

--- a/app/src/main/res/layout/item_booking.xml
+++ b/app/src/main/res/layout/item_booking.xml
@@ -174,6 +174,17 @@
                 android:text="@string/review_button"
                 android:visibility="gone" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/booking_voucher_button"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/voucher_button"
+                android:textColor="#2E7D32"
+                app:backgroundTint="#E6F4EA"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -159,6 +159,9 @@
         <action
             android:id="@+id/action_bookingsFragment_to_detailFragment"
             app:destination="@id/detailFragment" />
+        <action
+            android:id="@+id/action_bookingsFragment_to_voucherFragment"
+            app:destination="@id/voucherFragment" />
     </fragment>
 
     <fragment
@@ -193,6 +196,19 @@
         <argument
             android:name="activity_data"
             app:argType="com.example.myapplication.data.model.TourActivity" />
+        <action
+            android:id="@+id/action_detailFragment_to_voucherFragment"
+            app:destination="@id/voucherFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/voucherFragment"
+        android:name="com.example.myapplication.ui.bookings.VoucherFragment"
+        android:label="Voucher"
+        tools:layout="@layout/fragment_voucher">
+        <argument
+            android:name="bookingId"
+            app:argType="long" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -53,4 +53,24 @@
     <color name="onSurface">@color/md_theme_onSurface</color>
     <color name="error">@color/md_theme_error</color>
     <color name="onError">@color/md_theme_onError</color>
+
+    <!-- Restyle tokens -->
+    <color name="bg_lavender">#EFE8FA</color>
+    <color name="card_surface">#FFFFFF</color>
+    <color name="primary_violet">#7C5CFA</color>
+    <color name="primary_violet_pressed">#6645E0</color>
+    <color name="violet_soft">#E6DCFE</color>
+    <color name="violet_label">#7C5CFA</color>
+    <color name="state_done_bg">#DCEDD6</color>
+    <color name="state_done_fg">#3D6B33</color>
+    <color name="state_cancel_bg">#F8DADA</color>
+    <color name="state_cancel_fg">#9C2A2A</color>
+    <color name="state_pending_bg">#FFF1C2</color>
+    <color name="state_pending_fg">#8A6D00</color>
+    <color name="info_warm_bg">#FDE3CB</color>
+    <color name="info_warm_fg">#C75B1A</color>
+    <color name="price_orange">#E76A18</color>
+    <color name="text_primary">#1A1A2E</color>
+    <color name="text_secondary">#6E6B82</color>
+    <color name="star_amber">#F5B400</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,8 @@
     <string name="offline_banner_message">Estás sin conexión. Mostramos la información guardada en tu dispositivo.</string>
     <string name="bookings_empty_offline">Aún no tenemos información guardada. Conectate a internet para cargar tus actividades.</string>
     <string name="review_offline_error">Para calificar esta actividad necesitás conexión a internet.</string>
+    <string name="detail_offline_cache_miss">Esta actividad no fue sincronizada antes de perder la conexión. Conectate a internet para ver el detalle completo.</string>
+    <string name="no_data">No disponible</string>
     <string name="booking_cancelled_by_server">Una o más reservas fueron canceladas. El listado fue actualizado.</string>
     <string name="cancel_booking_offline_queued">Registramos tu solicitud de cancelación. La procesaremos automáticamente cuando vuelvas a tener conexión.</string>
     <string name="cancel_booking_offline_modal">Tu cancelación se procesará automáticamente cuando vuelvas a tener conexión.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,7 +207,6 @@
     <string name="status_pending_cancel">Cancelación pendiente</string>
         <string name="cancel_booking_pending_alert">La cancelación está pendiente de sincronización. Se procesará cuando recuperes la conexión.</string>
     <string name="status_pending">Pendiente</string>
-    <string name="status_pending_cancel">Cancelación pendiente</string>
 
     <!-- Profile activity summary -->
     <string name="profile_section_summary">Resumen de actividades</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,9 @@
     <string name="bookings_tab_historial">Historial</string>
     <string name="bookings_empty_activas">No tenés reservas activas.</string>
     <string name="bookings_empty_historial">No tenés actividades finalizadas.</string>
+
+    <!-- Mensaje especial para historial nunca sincronizado offline -->
+    <string name="bookings_empty_historial_never_synced">No hay datos de actividades porque nunca se sincronizó el historial con conexión a internet.</string>
     <string name="bookings_section_hoy">Hoy</string>
     <string name="bookings_section_proximas">Próximas</string>
     <string name="booking_badge_upcoming">Próximo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,23 @@
     <string name="bookings_filter_cancelled">Canceladas</string>
 
     <string name="review_button">Calificar</string>
+    <string name="voucher_title">Mi reserva</string>
+    <string name="voucher_confirmed">¡Reserva confirmada!</string>
+    <string name="voucher_confirmed_subtitle">Tu actividad está reservada.</string>
+    <string name="voucher_code_label">Código de reserva</string>
+    <string name="voucher_code_hint">Mostrá este código el día de la actividad</string>
+    <string name="voucher_save_title">Guardá este código</string>
+    <string name="voucher_save_subtitle">Lo vas a necesitar para el check-in.</string>
+    <string name="voucher_label_datetime">Fecha y hora</string>
+    <string name="voucher_label_duration">Duración</string>
+    <string name="voucher_label_guide">Guía</string>
+    <string name="voucher_label_participants">Participantes</string>
+    <string name="voucher_label_price">Precio total</string>
+    <string name="voucher_download_button">Descargar voucher</string>
+    <string name="voucher_button">Ver voucher</string>
+    <string name="voucher_participants">%d participante(s)</string>
+    <string name="voucher_pdf_saved">Voucher guardado en Descargas</string>
+    <string name="voucher_pdf_error">No se pudo generar el PDF</string>
     <string name="review_title">Calificar</string>
     <string name="review_send">Enviar</string>
     <string name="review_cancel">Cancelar</string>
@@ -181,6 +198,11 @@
     <string name="bookings_section_hoy">Hoy</string>
     <string name="bookings_section_proximas">Próximas</string>
     <string name="booking_badge_upcoming">Próximo</string>
+    <string name="status_confirmed">Confirmada</string>
+    <string name="status_completed">Finalizada</string>
+    <string name="status_cancelled">Cancelada</string>
+    <string name="status_pending">Pendiente</string>
+    <string name="status_pending_cancel">Cancelación pendiente</string>
 
     <!-- Profile activity summary -->
     <string name="profile_section_summary">Resumen de actividades</string>
@@ -224,4 +246,11 @@
 
     <!-- Offline -->
     <string name="offline_banner_message">Modo sin conexión - Los cambios que realices se procesarán cuando vuelvas a tener conexión.</string>
+    <string name="bookings_empty_offline">Sin conexión. Mostrando últimos datos guardados.</string>
+    <string name="review_offline_error">Necesitás conexión para calificar esta actividad.</string>
+    <string name="booking_cancelled_by_server">Una o más reservas fueron canceladas. El listado fue actualizado.</string>
+    <string name="cancel_booking_offline_queued">Cancelación guardada. Se procesará cuando recuperes la conexión.</string>
+
+    <!-- Voucher -->
+    <string name="voucher_label_meeting_point">Punto de encuentro</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,8 @@
     <string name="status_confirmed">Confirmada</string>
     <string name="status_completed">Finalizada</string>
     <string name="status_cancelled">Cancelada</string>
+    <string name="status_pending_cancel">Cancelación pendiente</string>
+        <string name="cancel_booking_pending_alert">La cancelación está pendiente de sincronización. Se procesará cuando recuperes la conexión.</string>
     <string name="status_pending">Pendiente</string>
     <string name="status_pending_cancel">Cancelación pendiente</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,11 +249,13 @@
     <string name="error_permission_denied">Permiso denegado. No se puede acceder a la galería.</string>
 
     <!-- Offline -->
-    <string name="offline_banner_message">Modo sin conexión - Los cambios que realices se procesarán cuando vuelvas a tener conexión.</string>
-    <string name="bookings_empty_offline">Sin conexión. Mostrando últimos datos guardados.</string>
-    <string name="review_offline_error">Necesitás conexión para calificar esta actividad.</string>
+    <string name="offline_banner_message">Estás sin conexión. Mostramos la información guardada en tu dispositivo.</string>
+    <string name="bookings_empty_offline">Aún no tenemos información guardada. Conectate a internet para cargar tus actividades.</string>
+    <string name="review_offline_error">Para calificar esta actividad necesitás conexión a internet.</string>
     <string name="booking_cancelled_by_server">Una o más reservas fueron canceladas. El listado fue actualizado.</string>
-    <string name="cancel_booking_offline_queued">Cancelación guardada. Se procesará cuando recuperes la conexión.</string>
+    <string name="cancel_booking_offline_queued">Registramos tu solicitud de cancelación. La procesaremos automáticamente cuando vuelvas a tener conexión.</string>
+    <string name="cancel_booking_offline_modal">Tu cancelación se procesará automáticamente cuando vuelvas a tener conexión.</string>
+    <string name="cancel_sync_error">No pudimos procesar la cancelación. Intentá nuevamente.</string>
 
     <!-- Voucher -->
     <string name="voucher_label_meeting_point">Punto de encuentro</string>


### PR DESCRIPTION
## Resumen

Se agregan dos funcionalidades sobre la sección de reservas: visualización del voucher de una reserva confirmada y soporte completo de modo sin conexión (caché, cancelación offline y sincronización automática).

---

## Funcionalidades nuevas

### 1. Voucher de reserva

- Nueva pantalla `VoucherFragment` accesible desde el card de una reserva activa.
- Muestra el código de voucher, nombre de la actividad, fecha, hora, duración, guía, destino, punto de encuentro, participantes y precio total.
- Botón de descarga de voucher (generación de imagen compartible).
- Navegación integrada al `nav_graph.xml` desde `BookingsFragment`.
- Nuevos drawables: `bg_voucher_code`, `ic_ticket`, `ic_shield`, `ic_download`, `ic_check_circle`, `ic_money`.

### 2. Modo sin conexión — Reservas

- **Banner de sin conexión**: se muestra en la pestaña Activas cuando el dispositivo no tiene red.
- **Caché de reservas confirmadas**: al listar reservas con estado `CONFIRMED`, los datos se persisten en Room (`OfflineBookingDao`) y se sirven desde caché cuando no hay conexión.
- **Cancelación offline**: si el usuario cancela sin red, la reserva se marca localmente como `PENDING_CANCEL` y se muestra en la UI con ese estado.
- **Sincronización automática**: `SyncCancellationsWorker` (WorkManager) procesa las cancelaciones pendientes en cuanto vuelve la conectividad, con retry exponencial.
- **SwipeRefreshLayout**: pull-to-refresh en la lista de reservas activas.
- Nuevas utilidades: `ConnectivityUtils` (chequeo de red) y `MainThreadUtils` (post al main thread desde background).
- `MainViewModel` detecta cambios de conectividad y los propaga a los fragments activos.

---

## Fixes y mejoras

| Área | Cambio |
|---|---|
| Booking adapter | Botón de voucher, diálogo de cancelación con política, botón calificar |

---

## Archivos principales modificados

```
ui/bookings/
  BookingsFragment.java            — swipe refresh, offline banner, voucher nav
  BookingAdapter.java              — botón voucher, diálogo cancelar con política
  VoucherFragment.java             — nuevo
  VoucherViewModel.java            — nuevo
  viewmodel/BookingsViewModel.java — offline detection, sync worker, caché

data/
  repository/BookingRepository.java  — caché confirmadas, cancel local, sync pendientes
  local/OfflineBookingDao.java        — queries: confirmed, historial, pendingCancel
  local/OfflineBookingEntity.java     — campos voucherCode, meetingPoint, pendingCancel
  work/SyncCancellationsWorker.java   — nuevo

util/
  ConnectivityUtils.java   — nuevo
  MainThreadUtils.java     — nuevo

res/layout/
  fragment_bookings.xml   — offline banner, SwipeRefreshLayout
  fragment_voucher.xml    — nuevo
```

---

## Consideraciones técnicas

- La sincronización de cancelaciones usa `ExistingWorkPolicy.KEEP` para evitar workers duplicados ante múltiples reconexiones.
- El caché de confirmadas (`replaceConfirmed`) y el de historial (`replaceHistorial`) son atómicos vía transacciones Room.
- El campo `pendingCancel` en la entidad Room permite mostrar el estado `PENDING_CANCEL` en la UI sin depender del servidor.
- No se requirieron cambios de backend para ninguna de las dos funcionalidades.


--
## Screenshots con el modo avion:
<img width="414" height="815" alt="imagen" src="https://github.com/user-attachments/assets/be61382b-7dee-4e23-8461-cd3fdfc91acb" />
<img width="427" height="814" alt="imagen" src="https://github.com/user-attachments/assets/1e10b19a-d1bf-4876-baaf-17eee2bf6bd1" />
<img width="388" height="827" alt="imagen" src="https://github.com/user-attachments/assets/4dcd7445-590a-4a6b-8eb6-3dbb3b635b4b" />
<img width="471" height="761" alt="imagen" src="https://github.com/user-attachments/assets/33d62a69-d91b-4b21-a43d-0fac672334e4" />




