### PR TITLE
Fix de adapters sin navegacion

### DIFF
--- a/app/src/main/java/com/example/myapplication/ui/explore/ExploreFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/explore/ExploreFragment.java
@@ -13,6 +13,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.example.myapplication.R;
@@ -60,6 +62,7 @@ public class ExploreFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(this).get(ExploreViewModel.class);
+        NavController navController = Navigation.findNavController(view);
 
         MaterialToolbar toolbar = view.findViewById(R.id.toolbar);
         toolbar.setTitle(getString(R.string.nav_explore));
@@ -86,6 +89,12 @@ public class ExploreFragment extends Fragment {
         recycler.setLayoutManager(new LinearLayoutManager(requireContext()));
         TourAdapter adapter = new TourAdapter(false, true);
         recycler.setAdapter(adapter);
+
+        adapter.setOnTourClickListener(activity -> {
+            Bundle bundle = new Bundle();
+            bundle.putSerializable("activity_data", activity);
+            navController.navigate(R.id.detailFragment, bundle);
+        });
 
         // Filter Toggle Logic
         btnToggleFilters.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/myapplication/ui/favorites/FavoritesAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/favorites/FavoritesAdapter.java
@@ -1,6 +1,5 @@
 package com.example.myapplication.ui.favorites;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,7 +8,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -27,11 +25,17 @@ public class FavoritesAdapter extends RecyclerView.Adapter<FavoritesAdapter.View
         void onRemoveRequested(TourActivity activity);
     }
 
+    public interface OnFavoriteClickListener {
+        void onOpenDetail(TourActivity activity, boolean scrollToBooking);
+    }
+
     private List<TourActivity> items = new ArrayList<>();
     private final OnFavoriteRemoveListener removeListener;
+    private final OnFavoriteClickListener clickListener;
 
-    public FavoritesAdapter(OnFavoriteRemoveListener removeListener) {
+    public FavoritesAdapter(OnFavoriteRemoveListener removeListener, OnFavoriteClickListener clickListener) {
         this.removeListener = removeListener;
+        this.clickListener = clickListener;
     }
 
     public void updateData(List<TourActivity> newData) {
@@ -90,16 +94,15 @@ public class FavoritesAdapter extends RecyclerView.Adapter<FavoritesAdapter.View
         holder.bookButton.setAlpha(soldOut ? 0.5f : 1f);
 
         View.OnClickListener goToDetail = v -> {
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("activity_data", activity);
-            Navigation.findNavController(v).navigate(R.id.detailFragment, bundle);
+            if (clickListener != null) {
+                clickListener.onOpenDetail(activity, false);
+            }
         };
 
         holder.bookButton.setOnClickListener(soldOut ? null : v -> {
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("activity_data", activity);
-            bundle.putBoolean("scroll_to_booking", true);
-            Navigation.findNavController(v).navigate(R.id.detailFragment, bundle);
+            if (clickListener != null) {
+                clickListener.onOpenDetail(activity, true);
+            }
         });
         holder.detailButton.setOnClickListener(goToDetail);
         holder.itemView.setOnClickListener(goToDetail);

--- a/app/src/main/java/com/example/myapplication/ui/favorites/FavoritesFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/favorites/FavoritesFragment.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -32,6 +34,7 @@ public class FavoritesFragment extends Fragment {
     private SwipeRefreshLayout swipeRefreshLayout;
     private FavoritesViewModel viewModel;
     private FavoritesAdapter adapter;
+    private NavController navController;
 
     @Nullable
     @Override
@@ -48,6 +51,7 @@ public class FavoritesFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         viewModel = new ViewModelProvider(this).get(FavoritesViewModel.class);
+        navController = Navigation.findNavController(view);
 
         setupRecyclerView();
         setupSwipeRefresh();
@@ -59,7 +63,17 @@ public class FavoritesFragment extends Fragment {
     }
 
     private void setupRecyclerView() {
-        adapter = new FavoritesAdapter(activity -> viewModel.toggleFavorite(activity.getId(), false));
+        adapter = new FavoritesAdapter(
+                activity -> viewModel.toggleFavorite(activity.getId(), false),
+                (activity, scrollToBooking) -> {
+                    Bundle bundle = new Bundle();
+                    bundle.putSerializable("activity_data", activity);
+                    if (scrollToBooking) {
+                        bundle.putBoolean("scroll_to_booking", true);
+                    }
+                    navController.navigate(R.id.detailFragment, bundle);
+                }
+        );
         recyclerViewFavorites.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerViewFavorites.setAdapter(adapter);
     }
@@ -108,6 +122,7 @@ public class FavoritesFragment extends Fragment {
         emptyView = null;
         progressBar = null;
         swipeRefreshLayout = null;
+        navController = null;
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/HomeFragment.java
@@ -57,6 +57,12 @@ public class HomeFragment extends androidx.fragment.app.Fragment {
         TourAdapter featuredAdapter = new TourAdapter(true, true);
         featuredRecycler.setAdapter(featuredAdapter);
 
+        featuredAdapter.setOnTourClickListener(activity -> {
+            Bundle bundle = new Bundle();
+            bundle.putSerializable("activity_data", activity);
+            navController.navigate(R.id.detailFragment, bundle);
+        });
+
         featuredAdapter.setOnFavoriteToggleListener((activity, targetFavorite) -> {
             if (activity.getId() == null) return;
             homeViewModel.toggleFavorite(activity.getId(), targetFavorite, null);
@@ -70,11 +76,27 @@ public class HomeFragment extends androidx.fragment.app.Fragment {
         newsAdapter = new NewsAdapter();
         newsRecycler.setAdapter(newsAdapter);
 
+        newsAdapter.setOnNewsClickListener(news -> {
+            Bundle bundle = new Bundle();
+            bundle.putLong("news_id", news.id);
+            if (news.relatedActivityId != null) {
+                bundle.putLong("related_activity_id", news.relatedActivityId);
+            }
+            navController.navigate(R.id.newsDetailFragment, bundle);
+        });
+
         RecyclerView promotionsRecycler = view.findViewById(R.id.promotions_recycler_view);
         promotionsRecycler.setLayoutManager(
                 new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
         promotionsAdapter = new PromotionsAdapter();
         promotionsRecycler.setAdapter(promotionsAdapter);
+
+        promotionsAdapter.setOnPromotionClickListener(promotion -> {
+            if (promotion.relatedActivityId == null) return;
+            Bundle bundle = new Bundle();
+            bundle.putLong("activity_id", promotion.relatedActivityId);
+            navController.navigate(R.id.detailFragment, bundle);
+        });
 
         newsViewModel.getNewsList().observe(getViewLifecycleOwner(), newsList -> {
             if (newsList != null) {

--- a/app/src/main/java/com/example/myapplication/ui/home/NewsAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/NewsAdapter.java
@@ -1,13 +1,11 @@
 package com.example.myapplication.ui.home;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.myapplication.R;
@@ -21,9 +19,18 @@ import java.util.Locale;
 public class NewsAdapter extends RecyclerView.Adapter<NewsAdapter.NewsViewHolder> {
 
     private List<NewsItem> newsItems;
+    private OnNewsClickListener clickListener;
+
+    public interface OnNewsClickListener {
+        void onNewsClick(NewsItem news);
+    }
 
     public NewsAdapter() {
         this.newsItems = java.util.Collections.emptyList();
+    }
+
+    public void setOnNewsClickListener(OnNewsClickListener listener) {
+        this.clickListener = listener;
     }
 
     public void updateData(List<NewsItem> newData) {
@@ -70,14 +77,10 @@ public class NewsAdapter extends RecyclerView.Adapter<NewsAdapter.NewsViewHolder
             holder.image.setImageResource(android.R.drawable.ic_menu_gallery);
         }
         
-        // Click listener
         holder.itemView.setOnClickListener(v -> {
-            Bundle bundle = new Bundle();
-            bundle.putLong("news_id", news.id);
-            if (news.relatedActivityId != null) {
-                bundle.putLong("related_activity_id", news.relatedActivityId);
+            if (clickListener != null) {
+                clickListener.onNewsClick(news);
             }
-            Navigation.findNavController(v).navigate(R.id.newsDetailFragment, bundle);
         });
     }
 

--- a/app/src/main/java/com/example/myapplication/ui/home/NewsFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/NewsFragment.java
@@ -11,6 +11,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -39,6 +41,7 @@ public class NewsFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         newsViewModel = new ViewModelProvider(this).get(NewsViewModel.class);
+        NavController navController = Navigation.findNavController(view);
 
         swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
         RecyclerView recyclerView = view.findViewById(R.id.news_recycler_view);
@@ -48,6 +51,15 @@ public class NewsFragment extends Fragment {
         recyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
         newsAdapter = new NewsAdapter();
         recyclerView.setAdapter(newsAdapter);
+
+        newsAdapter.setOnNewsClickListener(news -> {
+            Bundle bundle = new Bundle();
+            bundle.putLong("news_id", news.id);
+            if (news.relatedActivityId != null) {
+                bundle.putLong("related_activity_id", news.relatedActivityId);
+            }
+            navController.navigate(R.id.newsDetailFragment, bundle);
+        });
 
         swipeRefreshLayout.setOnRefreshListener(() -> {
             loadNews();

--- a/app/src/main/java/com/example/myapplication/ui/home/PromotionsAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/PromotionsAdapter.java
@@ -1,6 +1,5 @@
 package com.example.myapplication.ui.home;
 
-import android.os.Bundle;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.StrikethroughSpan;
@@ -10,7 +9,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.myapplication.R;
@@ -26,9 +24,18 @@ import java.util.regex.Pattern;
 public class PromotionsAdapter extends RecyclerView.Adapter<PromotionsAdapter.PromotionViewHolder> {
 
     private List<NewsItem> promotionItems;
+    private OnPromotionClickListener clickListener;
+
+    public interface OnPromotionClickListener {
+        void onPromotionClick(NewsItem promotion);
+    }
 
     public PromotionsAdapter() {
         this.promotionItems = java.util.Collections.emptyList();
+    }
+
+    public void setOnPromotionClickListener(OnPromotionClickListener listener) {
+        this.clickListener = listener;
     }
 
     public void updateData(List<NewsItem> newData) {
@@ -74,13 +81,9 @@ public class PromotionsAdapter extends RecyclerView.Adapter<PromotionsAdapter.Pr
             holder.image.setImageResource(android.R.drawable.ic_menu_gallery);
         }
         
-        // Click listener - Navigate directly to DetailFragment with activity_id
-        // relatedActivityId is the activity ID for promotions
         holder.itemView.setOnClickListener(v -> {
-            if (promotion.relatedActivityId != null) {
-                Bundle bundle = new Bundle();
-                bundle.putLong("activity_id", promotion.relatedActivityId);
-                Navigation.findNavController(v).navigate(R.id.detailFragment, bundle);
+            if (clickListener != null) {
+                clickListener.onPromotionClick(promotion);
             }
         });
     }

--- a/app/src/main/java/com/example/myapplication/ui/home/TourAdapter.java
+++ b/app/src/main/java/com/example/myapplication/ui/home/TourAdapter.java
@@ -2,7 +2,6 @@ package com.example.myapplication.ui.home;
 
 import android.annotation.SuppressLint;
 import android.graphics.Paint;
-import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,7 +9,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
-import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.myapplication.R;
@@ -31,11 +29,16 @@ public class TourAdapter extends RecyclerView.Adapter<TourAdapter.TourViewHolder
         void onFavoriteToggle(TourActivity activity, boolean targetFavorite);
     }
 
+    public interface OnTourClickListener {
+        void onTourClick(TourActivity activity);
+    }
+
     private List<TourActivity> tourActivities;
     private final boolean isHorizontal;
     private final boolean isCompact;
     private final boolean isFavoritesSection;
     private OnFavoriteToggleListener favoriteToggleListener;
+    private OnTourClickListener tourClickListener;
 
     public TourAdapter(boolean isHorizontal) {
         this(isHorizontal, isHorizontal, false);
@@ -59,6 +62,10 @@ public class TourAdapter extends RecyclerView.Adapter<TourAdapter.TourViewHolder
 
     public void setOnFavoriteToggleListener(OnFavoriteToggleListener listener) {
         this.favoriteToggleListener = listener;
+    }
+
+    public void setOnTourClickListener(OnTourClickListener listener) {
+        this.tourClickListener = listener;
     }
 
     @NonNull
@@ -262,9 +269,9 @@ public class TourAdapter extends RecyclerView.Adapter<TourAdapter.TourViewHolder
         }
 
         View.OnClickListener detailListener = v -> {
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("activity_data", activity);
-            Navigation.findNavController(v).navigate(R.id.detailFragment, bundle);
+            if (tourClickListener != null) {
+                tourClickListener.onTourClick(activity);
+            }
         };
 
         holder.itemView.setOnClickListener(detailListener);


### PR DESCRIPTION
ESTA PR NO SE VA A MERGEAR PORQUE QUEDA POCO PARA LE ENTREGA, ASI EVITAMOS PROBLEMAS, PERO QUIZÁ EN UN FUTURO SI. 


Descripción para la PR
Este PR refactoriza los RecyclerView.Adapter para que no ejecuten navegación (Navigation.findNavController(...).navigate(...)) y, en su lugar, expongan callbacks/listeners. La navegación se mueve a los Fragment que los usan, alineando el código con la práctica enseñada (el adapter no debe conocer NavController/destinos).

Cambios principales:

TourAdapter: agrega OnTourClickListener y delega el click del item al Fragment.
NewsAdapter: agrega OnNewsClickListener y delega click de noticia.
PromotionsAdapter: agrega OnPromotionClickListener y delega click de promo.
FavoritesAdapter: agrega OnFavoriteClickListener y delega apertura de detalle (incluyendo scroll_to_booking).
Wiring de listeners en HomeFragment, ExploreFragment, NewsFragment, FavoritesFragment.