### PR TITLE
agregar qr y vouchers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,13 @@ dependencies {
     // Google Maps (Feature 10)
     implementation(libs.play.services.maps)
 
+    // CameraX + ML Kit — Check-in por QR (Feature 11)
+    implementation(libs.camera.core)
+    implementation(libs.camera.camera2)
+    implementation(libs.camera.lifecycle)
+    implementation(libs.camera.view)
+    implementation(libs.mlkit.barcode)
+
     testImplementation(libs.junit)
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation("org.mockito:mockito-core:5.11.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Check-in por QR (Feature 11) -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Recordatorios y Avisos (Feature 12) -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
@@ -32,6 +38,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:label="@string/app_name"
             android:theme="@style/Theme.XploreNow">
             <intent-filter>
@@ -39,6 +46,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Servicio que escucha novedades (reprogramación/cancelación) — Feature 12 -->
+        <service
+            android:name=".service.NovedadesPollingService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
 
         <!-- Desactiva el inicializador automático de WorkManager para usar la config de Hilt -->
         <provider

--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -1,21 +1,31 @@
 package com.example.myapplication;
 
+import android.Manifest;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.Toast;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import com.example.myapplication.data.session.SessionManager;
+import com.example.myapplication.service.NovedadesPollingService;
 import com.example.myapplication.ui.main.MainViewModel;
+import com.example.myapplication.util.NotificationHelper;
 import com.example.myapplication.util.ThemePreferences;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -29,6 +39,13 @@ public class MainActivity extends AppCompatActivity {
     SessionManager sessionManager;
 
     private NavController navController;
+
+    private final ActivityResultLauncher<String> notifPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
+                if (!granted) {
+                    Toast.makeText(this, R.string.notif_permission_denied, Toast.LENGTH_LONG).show();
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -159,6 +176,47 @@ public class MainActivity extends AppCompatActivity {
                 navController.navigate(R.id.loginFragment);
             }
         });
+
+        // Recordatorios y Avisos (Feature 12)
+        NotificationHelper.createChannels(this);
+        pedirPermisoNotificaciones();
+        iniciarServicioNovedades();
+        handleVoucherDeepLink(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleVoucherDeepLink(intent);
+    }
+
+    /** POST_NOTIFICATIONS es permiso en runtime solo desde API 33. */
+    private void pedirPermisoNotificaciones() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED) {
+            notifPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+        }
+    }
+
+    /** Inicia el foreground service que escucha reprogramaciones/cancelaciones. */
+    private void iniciarServicioNovedades() {
+        if (!sessionManager.hasValidSession()) return;
+        Intent intent = new Intent(this, NovedadesPollingService.class);
+        ContextCompat.startForegroundService(this, intent);
+    }
+
+    /** Abre el voucher de una reserva cuando se toca una notificación. */
+    private void handleVoucherDeepLink(Intent intent) {
+        if (intent == null || navController == null) return;
+        long bookingId = intent.getLongExtra(NotificationHelper.EXTRA_OPEN_VOUCHER_BOOKING_ID, -1L);
+        if (bookingId <= 0 || !sessionManager.hasValidSession()) return;
+
+        intent.removeExtra(NotificationHelper.EXTRA_OPEN_VOUCHER_BOOKING_ID);
+        Bundle args = new Bundle();
+        args.putLong("bookingId", bookingId);
+        navController.navigate(R.id.voucherFragment, args);
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/data/work/ActivityReminderWorker.java
+++ b/app/src/main/java/com/example/myapplication/data/work/ActivityReminderWorker.java
@@ -1,0 +1,52 @@
+package com.example.myapplication.data.work;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.hilt.work.HiltWorker;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.example.myapplication.R;
+import com.example.myapplication.util.NotificationHelper;
+
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
+
+/**
+ * Dispara el recordatorio 24 h antes de una actividad (Feature 12, requisito 29).
+ * Se programa con {@link com.example.myapplication.util.ReminderScheduler} y el
+ * tap de la notificación abre directamente el voucher de la reserva.
+ */
+@HiltWorker
+public class ActivityReminderWorker extends Worker {
+
+    public static final String KEY_BOOKING_ID = "booking_id";
+    public static final String KEY_ACTIVITY_NAME = "activity_name";
+
+    @AssistedInject
+    public ActivityReminderWorker(@Assisted @NonNull Context context,
+                                  @Assisted @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        long bookingId = getInputData().getLong(KEY_BOOKING_ID, -1L);
+        if (bookingId <= 0) return Result.success();
+
+        String activityName = getInputData().getString(KEY_ACTIVITY_NAME);
+        Context ctx = getApplicationContext();
+
+        NotificationHelper.showBookingNotification(
+                ctx,
+                NotificationHelper.CHANNEL_REMINDERS,
+                bookingId,
+                ctx.getString(R.string.notif_reminder_title,
+                        activityName != null ? activityName : ""),
+                ctx.getString(R.string.notif_reminder_text));
+
+        return Result.success();
+    }
+}

--- a/app/src/main/java/com/example/myapplication/service/NovedadesPollingService.java
+++ b/app/src/main/java/com/example/myapplication/service/NovedadesPollingService.java
@@ -1,0 +1,177 @@
+package com.example.myapplication.service;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import com.example.myapplication.R;
+import com.example.myapplication.data.local.OfflineBookingDao;
+import com.example.myapplication.data.local.OfflineBookingEntity;
+import com.example.myapplication.data.model.BookingResponse;
+import com.example.myapplication.data.model.BookingsPageResponse;
+import com.example.myapplication.data.network.BookingService;
+import com.example.myapplication.data.repository.SessionRepository;
+import com.example.myapplication.util.NotificationHelper;
+import com.example.myapplication.util.ReminderScheduler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
+import retrofit2.Response;
+
+/**
+ * Foreground service que escucha novedades de las reservas del usuario y avisa
+ * de inmediato cuando la operadora reprograma o cancela una actividad
+ * (Feature 12, requisito 30).
+ *
+ * <p>Replica el patrón del {@code PollingService} de referencia de
+ * mobile-practices-android (foreground service + NotificationChannel + hilo de
+ * polling), adaptado al backend de XploreNow: consulta periódicamente las
+ * reservas y compara contra el último estado conocido para detectar cambios de
+ * horario (reprogramación) o de estado a {@code CANCELLED}.</p>
+ */
+@AndroidEntryPoint
+public class NovedadesPollingService extends Service {
+
+    private static final String TAG = "NovedadesPolling";
+    private static final int NOTIF_ID_FOREGROUND = 4101;
+    private static final long POLL_INTERVAL_MILLIS = 60_000L; // 60 s
+
+    @Inject BookingService bookingService;
+    @Inject OfflineBookingDao offlineBookingDao;
+    @Inject SessionRepository sessionRepository;
+
+    private Thread pollingThread;
+    private volatile boolean running = false;
+
+    // Último estado conocido por reserva (id → horario / estado).
+    private final Map<Long, String> lastStartTime = new HashMap<>();
+    private final Map<Long, String> lastStatus = new HashMap<>();
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        NotificationHelper.createChannels(this);
+
+        Notification foreground = new NotificationCompat.Builder(this, NotificationHelper.CHANNEL_NOVEDADES)
+                .setContentTitle(getString(R.string.app_name))
+                .setContentText(getString(R.string.notif_service_listening))
+                .setSmallIcon(R.drawable.ic_ticket)
+                .setOngoing(true)
+                .build();
+        startForeground(NOTIF_ID_FOREGROUND, foreground);
+
+        if (!running) {
+            running = true;
+            pollingThread = new Thread(this::loopDePolling, "novedades-polling");
+            pollingThread.start();
+        }
+        return START_STICKY;
+    }
+
+    private void loopDePolling() {
+        long userId = sessionRepository.getUserId();
+        if (userId <= 0) {
+            Log.d(TAG, "Sin sesión activa; no se inicia el polling");
+            return;
+        }
+
+        seedFromCache(userId);
+
+        while (running && !Thread.currentThread().isInterrupted()) {
+            try {
+                consultarNovedades(userId);
+                Thread.sleep(POLL_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                Log.w(TAG, "Error consultando novedades", e);
+                try {
+                    Thread.sleep(POLL_INTERVAL_MILLIS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        Log.d(TAG, "Loop de polling finalizado");
+    }
+
+    /** Inicializa el estado conocido con lo cacheado en Room para detectar cambios offline. */
+    private void seedFromCache(long userId) {
+        List<OfflineBookingEntity> cached = offlineBookingDao.getConfirmedByUser(userId);
+        if (cached == null) return;
+        for (OfflineBookingEntity e : cached) {
+            lastStartTime.put(e.id, e.sessionStartTime);
+            lastStatus.put(e.id, e.status);
+        }
+    }
+
+    private void consultarNovedades(long userId) throws Exception {
+        Response<BookingsPageResponse> resp =
+                bookingService.listBookings("users/" + userId + "/bookings").execute();
+        if (!resp.isSuccessful() || resp.body() == null || resp.body().items == null) {
+            return;
+        }
+
+        for (BookingResponse b : resp.body().items) {
+            if (b == null || b.id == null) continue;
+
+            String prevStatus = lastStatus.get(b.id);
+            String prevStart = lastStartTime.get(b.id);
+
+            boolean known = prevStatus != null;
+
+            // Cancelación por la operadora: pasó de CONFIRMED a CANCELLED.
+            if (known && "CANCELLED".equalsIgnoreCase(b.status)
+                    && !"CANCELLED".equalsIgnoreCase(prevStatus)) {
+                NotificationHelper.showBookingNotification(this,
+                        NotificationHelper.CHANNEL_NOVEDADES, b.id,
+                        getString(R.string.notif_cancelled_title),
+                        getString(R.string.notif_cancelled_text, safe(b.activityName)));
+                ReminderScheduler.cancel(this, b.id);
+            }
+            // Reprogramación: cambió el horario de inicio de una reserva activa.
+            else if (known && "CONFIRMED".equalsIgnoreCase(b.status)
+                    && b.sessionStartTime != null
+                    && !b.sessionStartTime.equals(prevStart)) {
+                NotificationHelper.showBookingNotification(this,
+                        NotificationHelper.CHANNEL_NOVEDADES, b.id,
+                        getString(R.string.notif_rescheduled_title),
+                        getString(R.string.notif_rescheduled_text, safe(b.activityName)));
+                ReminderScheduler.schedule(this, b.id, b.activityName, b.sessionStartTime);
+            }
+
+            lastStatus.put(b.id, b.status);
+            lastStartTime.put(b.id, b.sessionStartTime);
+        }
+    }
+
+    private String safe(String s) {
+        return s != null ? s : "";
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        running = false;
+        if (pollingThread != null) {
+            pollingThread.interrupt();
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 import com.example.myapplication.R;
 import com.example.myapplication.data.local.OfflineBookingEntity;
+import com.example.myapplication.util.CheckInStore;
 import com.example.myapplication.util.FormatUtils;
 import com.google.android.material.button.MaterialButton;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -34,6 +35,7 @@ public class VoucherFragment extends Fragment {
 
     private VoucherViewModel viewModel;
     private OfflineBookingEntity currentBooking;
+    private MaterialButton checkInButton;
 
     @Nullable
     @Override
@@ -49,7 +51,7 @@ public class VoucherFragment extends Fragment {
         MaterialButton downloadButton = view.findViewById(R.id.voucher_download_button);
         downloadButton.setOnClickListener(v -> generatePdf());
 
-        MaterialButton checkInButton = view.findViewById(R.id.voucher_checkin_button);
+        checkInButton = view.findViewById(R.id.voucher_checkin_button);
         checkInButton.setOnClickListener(v -> openCheckInScanner());
 
         viewModel = new ViewModelProvider(this).get(VoucherViewModel.class);
@@ -87,16 +89,32 @@ public class VoucherFragment extends Fragment {
         }
 
         setText(view, R.id.voucher_code, b.voucherCode != null ? b.voucherCode : "—");
+        bindCheckInState(view, b);
     }
 
     private void openCheckInScanner() {
         if (currentBooking == null) return;
         Bundle args = new Bundle();
+        args.putLong("bookingId", currentBooking.id);
         args.putString("voucherCode", currentBooking.voucherCode);
         if (currentBooking.sessionId != null) args.putLong("sessionId", currentBooking.sessionId);
         args.putString("activityName", currentBooking.activityName);
         Navigation.findNavController(requireView())
                 .navigate(R.id.action_voucherFragment_to_checkInScanFragment, args);
+    }
+
+    private void bindCheckInState(View view, OfflineBookingEntity booking) {
+        boolean confirmed = CheckInStore.isConfirmed(requireContext(), booking);
+        View checkInConfirmedBanner = view.findViewById(R.id.voucher_checkin_confirmed_banner);
+        if (checkInConfirmedBanner != null) {
+            checkInConfirmedBanner.setVisibility(confirmed ? View.VISIBLE : View.GONE);
+        }
+        if (checkInButton != null) {
+            checkInButton.setEnabled(!confirmed);
+            checkInButton.setText(confirmed
+                    ? R.string.voucher_checkin_confirmed_button
+                    : R.string.checkin_button);
+        }
     }
 
     private void generatePdf() {

--- a/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/VoucherFragment.java
@@ -49,6 +49,9 @@ public class VoucherFragment extends Fragment {
         MaterialButton downloadButton = view.findViewById(R.id.voucher_download_button);
         downloadButton.setOnClickListener(v -> generatePdf());
 
+        MaterialButton checkInButton = view.findViewById(R.id.voucher_checkin_button);
+        checkInButton.setOnClickListener(v -> openCheckInScanner());
+
         viewModel = new ViewModelProvider(this).get(VoucherViewModel.class);
         viewModel.getBooking().observe(getViewLifecycleOwner(), booking -> {
             if (booking != null) {
@@ -84,6 +87,16 @@ public class VoucherFragment extends Fragment {
         }
 
         setText(view, R.id.voucher_code, b.voucherCode != null ? b.voucherCode : "—");
+    }
+
+    private void openCheckInScanner() {
+        if (currentBooking == null) return;
+        Bundle args = new Bundle();
+        args.putString("voucherCode", currentBooking.voucherCode);
+        if (currentBooking.sessionId != null) args.putLong("sessionId", currentBooking.sessionId);
+        args.putString("activityName", currentBooking.activityName);
+        Navigation.findNavController(requireView())
+                .navigate(R.id.action_voucherFragment_to_checkInScanFragment, args);
     }
 
     private void generatePdf() {

--- a/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
+++ b/app/src/main/java/com/example/myapplication/ui/bookings/viewmodel/BookingsViewModel.java
@@ -18,6 +18,7 @@ import com.example.myapplication.data.repository.ProfileRepository;
 import com.example.myapplication.data.repository.ReviewRepository;
 import com.example.myapplication.data.work.SyncCancellationsWorker;
 import com.example.myapplication.util.NetworkMonitor;
+import com.example.myapplication.util.ReminderScheduler;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
 import androidx.work.ExistingWorkPolicy;
@@ -221,6 +222,8 @@ public class BookingsViewModel extends ViewModel {
                     }
                 }
                 _bookings.setValue(fresh);
+                // Recordatorios 24 h antes de cada actividad confirmada (Feature 12)
+                ReminderScheduler.scheduleAll(context, fresh);
             }
 
             @Override

--- a/app/src/main/java/com/example/myapplication/ui/checkin/CheckInScanFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/checkin/CheckInScanFragment.java
@@ -1,0 +1,257 @@
+package com.example.myapplication.ui.checkin;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageAnalysis;
+import androidx.camera.core.ImageProxy;
+import androidx.camera.core.Preview;
+import androidx.camera.lifecycle.ProcessCameraProvider;
+import androidx.camera.view.PreviewView;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+
+import com.example.myapplication.R;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.mlkit.vision.barcode.BarcodeScanner;
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
+import com.google.mlkit.vision.barcode.BarcodeScanning;
+import com.google.mlkit.vision.barcode.common.Barcode;
+import com.google.mlkit.vision.common.InputImage;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import dagger.hilt.android.AndroidEntryPoint;
+
+/**
+ * Check-in por QR (Feature 11). El guía muestra un código QR en el punto de
+ * encuentro; el viajero lo escanea con la cámara y la app confirma su asistencia.
+ *
+ * <p>Basado en la implementación de referencia {@code QrScanFragment} de
+ * mobile-practices-android (CameraX + ML Kit), adaptado al dominio de XploreNow:
+ * el contenido del QR se valida contra la reserva actual y se muestra un
+ * resultado visual claro (verde = confirmado, rojo = QR inválido).</p>
+ */
+@AndroidEntryPoint
+public class CheckInScanFragment extends Fragment {
+
+    private static final String TAG = "CheckInScanFragment";
+
+    private static final int COLOR_SUCCESS = Color.parseColor("#1B5E20");
+    private static final int COLOR_ERROR = Color.parseColor("#B71C1C");
+
+    private PreviewView previewView;
+    private View hint;
+    private LinearLayout resultPanel;
+    private ImageView ivResultIcon;
+    private TextView tvResultTitle;
+    private TextView tvResultMessage;
+
+    private ExecutorService cameraExecutor;
+    private BarcodeScanner barcodeScanner;
+    private ActivityResultLauncher<String> requestPermissionLauncher;
+
+    // Datos de la reserva con la que validamos el QR escaneado.
+    private String expectedVoucherCode;
+    private long expectedSessionId;
+    private String activityName;
+
+    // Evita procesar múltiples frames una vez que ya mostramos un resultado.
+    private final AtomicBoolean handled = new AtomicBoolean(false);
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getArguments() != null) {
+            expectedVoucherCode = getArguments().getString("voucherCode");
+            expectedSessionId = getArguments().getLong("sessionId", -1L);
+            activityName = getArguments().getString("activityName");
+        }
+
+        requestPermissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestPermission(),
+                granted -> {
+                    if (granted) {
+                        iniciarCamara();
+                    } else {
+                        Toast.makeText(requireContext(),
+                                R.string.checkin_permission_denied, Toast.LENGTH_LONG).show();
+                    }
+                });
+
+        BarcodeScannerOptions opciones = new BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                .build();
+        barcodeScanner = BarcodeScanning.getClient(opciones);
+        cameraExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_check_in_scan, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        previewView = view.findViewById(R.id.previewView);
+        hint = view.findViewById(R.id.tvHint);
+        resultPanel = view.findViewById(R.id.resultPanel);
+        ivResultIcon = view.findViewById(R.id.ivResultIcon);
+        tvResultTitle = view.findViewById(R.id.tvResultTitle);
+        tvResultMessage = view.findViewById(R.id.tvResultMessage);
+
+        view.findViewById(R.id.btnScanAgain).setOnClickListener(v -> reanudarEscaneo());
+
+        pedirPermisoCamara();
+    }
+
+    private void pedirPermisoCamara() {
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
+                == PackageManager.PERMISSION_GRANTED) {
+            iniciarCamara();
+        } else {
+            requestPermissionLauncher.launch(Manifest.permission.CAMERA);
+        }
+    }
+
+    private void iniciarCamara() {
+        ListenableFuture<ProcessCameraProvider> futuro =
+                ProcessCameraProvider.getInstance(requireContext());
+
+        futuro.addListener(() -> {
+            try {
+                ProcessCameraProvider cameraProvider = futuro.get();
+
+                Preview preview = new Preview.Builder().build();
+                preview.setSurfaceProvider(previewView.getSurfaceProvider());
+
+                ImageAnalysis analisis = new ImageAnalysis.Builder()
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build();
+                analisis.setAnalyzer(cameraExecutor, this::analizarFrame);
+
+                cameraProvider.unbindAll();
+                cameraProvider.bindToLifecycle(
+                        getViewLifecycleOwner(), CameraSelector.DEFAULT_BACK_CAMERA, preview, analisis);
+
+            } catch (ExecutionException | InterruptedException e) {
+                Log.e(TAG, "Error al obtener ProcessCameraProvider", e);
+            }
+        }, ContextCompat.getMainExecutor(requireContext()));
+    }
+
+    @androidx.annotation.OptIn(markerClass = androidx.camera.core.ExperimentalGetImage.class)
+    private void analizarFrame(@NonNull ImageProxy imageProxy) {
+        if (handled.get() || imageProxy.getImage() == null) {
+            imageProxy.close();
+            return;
+        }
+
+        InputImage imagen = InputImage.fromMediaImage(
+                imageProxy.getImage(),
+                imageProxy.getImageInfo().getRotationDegrees());
+
+        barcodeScanner.process(imagen)
+                .addOnSuccessListener(codigos -> {
+                    for (Barcode codigo : codigos) {
+                        String valor = codigo.getRawValue();
+                        if (valor != null && handled.compareAndSet(false, true)) {
+                            requireActivity().runOnUiThread(() -> mostrarResultado(valor));
+                            break;
+                        }
+                    }
+                })
+                .addOnFailureListener(e -> Log.w(TAG, "Error en ML Kit barcode scan", e))
+                .addOnCompleteListener(tarea -> imageProxy.close());
+    }
+
+    /** Valida el contenido del QR contra la reserva y muestra el resultado verde/rojo. */
+    private void mostrarResultado(String rawValue) {
+        if (!isAdded()) return;
+        boolean valido = esQrDeLaReserva(rawValue);
+
+        hint.setVisibility(View.GONE);
+        resultPanel.setVisibility(View.VISIBLE);
+
+        if (valido) {
+            resultPanel.setBackgroundColor(COLOR_SUCCESS);
+            ivResultIcon.setImageResource(R.drawable.ic_check_circle);
+            tvResultTitle.setText(R.string.checkin_success_title);
+            tvResultMessage.setText(getString(R.string.checkin_success_message,
+                    activityName != null ? activityName : ""));
+        } else {
+            resultPanel.setBackgroundColor(COLOR_ERROR);
+            ivResultIcon.setImageResource(R.drawable.ic_error_circle);
+            tvResultTitle.setText(R.string.checkin_error_title);
+            tvResultMessage.setText(R.string.checkin_error_message);
+        }
+    }
+
+    /**
+     * El QR del guía es válido si su contenido coincide con la reserva actual:
+     * puede ser el código de voucher en texto plano, o un JSON que contenga
+     * {@code voucherCode} o {@code sessionId}.
+     */
+    private boolean esQrDeLaReserva(String rawValue) {
+        String valor = rawValue.trim();
+
+        // 1) JSON con voucherCode / sessionId
+        try {
+            JSONObject json = new JSONObject(valor);
+            if (expectedVoucherCode != null && json.has("voucherCode")
+                    && expectedVoucherCode.equalsIgnoreCase(json.optString("voucherCode").trim())) {
+                return true;
+            }
+            if (expectedSessionId > 0 && json.has("sessionId")
+                    && expectedSessionId == json.optLong("sessionId", -1L)) {
+                return true;
+            }
+            return false;
+        } catch (JSONException ignored) {
+            // No es JSON: lo tratamos como código de voucher en texto plano.
+        }
+
+        // 2) Texto plano == código de voucher
+        return expectedVoucherCode != null && expectedVoucherCode.equalsIgnoreCase(valor);
+    }
+
+    private void reanudarEscaneo() {
+        resultPanel.setVisibility(View.GONE);
+        hint.setVisibility(View.VISIBLE);
+        handled.set(false);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        cameraExecutor.shutdown();
+        barcodeScanner.close();
+    }
+}

--- a/app/src/main/java/com/example/myapplication/ui/checkin/CheckInScanFragment.java
+++ b/app/src/main/java/com/example/myapplication/ui/checkin/CheckInScanFragment.java
@@ -25,8 +25,10 @@ import androidx.camera.lifecycle.ProcessCameraProvider;
 import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
 
 import com.example.myapplication.R;
+import com.example.myapplication.util.CheckInStore;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.mlkit.vision.barcode.BarcodeScanner;
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
@@ -73,6 +75,7 @@ public class CheckInScanFragment extends Fragment {
     private ActivityResultLauncher<String> requestPermissionLauncher;
 
     // Datos de la reserva con la que validamos el QR escaneado.
+    private long bookingId;
     private String expectedVoucherCode;
     private long expectedSessionId;
     private String activityName;
@@ -85,6 +88,7 @@ public class CheckInScanFragment extends Fragment {
         super.onCreate(savedInstanceState);
 
         if (getArguments() != null) {
+            bookingId = getArguments().getLong("bookingId", -1L);
             expectedVoucherCode = getArguments().getString("voucherCode");
             expectedSessionId = getArguments().getLong("sessionId", -1L);
             activityName = getArguments().getString("activityName");
@@ -127,7 +131,8 @@ public class CheckInScanFragment extends Fragment {
         tvResultTitle = view.findViewById(R.id.tvResultTitle);
         tvResultMessage = view.findViewById(R.id.tvResultMessage);
 
-        view.findViewById(R.id.btnScanAgain).setOnClickListener(v -> reanudarEscaneo());
+        view.findViewById(R.id.btnScanAgain).setOnClickListener(v ->
+                NavHostFragment.findNavController(this).popBackStack());
 
         pedirPermisoCamara();
     }
@@ -201,6 +206,9 @@ public class CheckInScanFragment extends Fragment {
         resultPanel.setVisibility(View.VISIBLE);
 
         if (valido) {
+            if (bookingId > 0) {
+                CheckInStore.markConfirmed(requireContext(), bookingId);
+            }
             resultPanel.setBackgroundColor(COLOR_SUCCESS);
             ivResultIcon.setImageResource(R.drawable.ic_check_circle);
             tvResultTitle.setText(R.string.checkin_success_title);
@@ -240,12 +248,6 @@ public class CheckInScanFragment extends Fragment {
 
         // 2) Texto plano == código de voucher
         return expectedVoucherCode != null && expectedVoucherCode.equalsIgnoreCase(valor);
-    }
-
-    private void reanudarEscaneo() {
-        resultPanel.setVisibility(View.GONE);
-        hint.setVisibility(View.VISIBLE);
-        handled.set(false);
     }
 
     @Override

--- a/app/src/main/java/com/example/myapplication/util/CheckInStore.java
+++ b/app/src/main/java/com/example/myapplication/util/CheckInStore.java
@@ -1,0 +1,33 @@
+package com.example.myapplication.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.example.myapplication.data.local.OfflineBookingEntity;
+
+public final class CheckInStore {
+
+    private static final String PREFS_NAME = "check_in_store";
+    private static final String KEY_PREFIX = "booking_";
+
+    private CheckInStore() {}
+
+    public static void markConfirmed(Context context, long bookingId) {
+        getPrefs(context).edit()
+                .putBoolean(KEY_PREFIX + bookingId, true)
+                .apply();
+    }
+
+    public static boolean isConfirmed(Context context, OfflineBookingEntity booking) {
+        return booking != null && isConfirmed(context, booking.id);
+    }
+
+    public static boolean isConfirmed(Context context, long bookingId) {
+        return getPrefs(context).getBoolean(KEY_PREFIX + bookingId, false);
+    }
+
+    private static SharedPreferences getPrefs(Context context) {
+        return context.getApplicationContext()
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+}

--- a/app/src/main/java/com/example/myapplication/util/FormatUtils.java
+++ b/app/src/main/java/com/example/myapplication/util/FormatUtils.java
@@ -91,6 +91,33 @@ public final class FormatUtils {
      * Ejemplo entrada: "2024-01-15T14:30:00Z"
      * Ejemplo salida: "15/01/2024 17:30" (UTC+3)
      */
+    /**
+     * Convierte un timestamp ISO de sesión a epoch millis. Soporta el formato
+     * con sufijo "Z" (UTC) y, como fallback, "yyyy-MM-dd'T'HH:mm:ss". Devuelve
+     * -1 si no se puede parsear.
+     */
+    public static long parseToEpochMillis(String iso) {
+        if (iso == null || iso.isEmpty()) return -1L;
+        String[] patterns = {
+                "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                "yyyy-MM-dd'T'HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm"
+        };
+        for (String pattern : patterns) {
+            try {
+                SimpleDateFormat fmt = new SimpleDateFormat(pattern, Locale.US);
+                if (pattern.endsWith("'Z'")) {
+                    fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+                }
+                Date date = fmt.parse(iso);
+                if (date != null) return date.getTime();
+            } catch (Exception ignored) {
+                // probar siguiente patrón
+            }
+        }
+        return -1L;
+    }
+
     public static String formatStartTimeWithUTC3(String iso) {
         if (iso == null || iso.isEmpty()) return "";
         try {

--- a/app/src/main/java/com/example/myapplication/util/NotificationHelper.java
+++ b/app/src/main/java/com/example/myapplication/util/NotificationHelper.java
@@ -1,0 +1,88 @@
+package com.example.myapplication.util;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+
+import com.example.myapplication.MainActivity;
+import com.example.myapplication.R;
+
+/**
+ * Centraliza la creación de canales y el armado de notificaciones para los
+ * Recordatorios y Avisos (Feature 12).
+ *
+ * <p>Sigue el patrón de la implementación de referencia de
+ * mobile-practices-android (NotificationChannel + NotificationCompat), agregando
+ * un {@link PendingIntent} que lleva directo al voucher de la reserva.</p>
+ */
+public final class NotificationHelper {
+
+    public static final String CHANNEL_REMINDERS = "reminders_channel";
+    public static final String CHANNEL_NOVEDADES = "novedades_channel";
+
+    /** Extra que viaja en el intent para abrir el voucher de una reserva. */
+    public static final String EXTRA_OPEN_VOUCHER_BOOKING_ID = "open_voucher_booking_id";
+
+    private NotificationHelper() {}
+
+    /** Crea los canales de notificación (no-op en API < 26 y si ya existen). */
+    public static void createChannels(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager manager = context.getSystemService(NotificationManager.class);
+        if (manager == null) return;
+
+        NotificationChannel reminders = new NotificationChannel(
+                CHANNEL_REMINDERS,
+                context.getString(R.string.notif_channel_reminders_name),
+                NotificationManager.IMPORTANCE_HIGH);
+        reminders.setDescription(context.getString(R.string.notif_channel_reminders_desc));
+        manager.createNotificationChannel(reminders);
+
+        NotificationChannel novedades = new NotificationChannel(
+                CHANNEL_NOVEDADES,
+                context.getString(R.string.notif_channel_novedades_name),
+                NotificationManager.IMPORTANCE_HIGH);
+        novedades.setDescription(context.getString(R.string.notif_channel_novedades_desc));
+        manager.createNotificationChannel(novedades);
+    }
+
+    /**
+     * Muestra una notificación cuyo tap abre el voucher de la reserva indicada.
+     * El id de la notificación se deriva del bookingId para que el aviso de una
+     * misma reserva se reemplace en lugar de duplicarse.
+     */
+    public static void showBookingNotification(Context context, String channelId,
+                                               long bookingId, String title, String text) {
+        createChannels(context);
+
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(EXTRA_OPEN_VOUCHER_BOOKING_ID, bookingId);
+
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent pending = PendingIntent.getActivity(
+                context, (int) bookingId, intent, flags);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(R.drawable.ic_ticket)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(pending)
+                .setAutoCancel(true);
+
+        NotificationManager manager = context.getSystemService(NotificationManager.class);
+        if (manager != null) {
+            manager.notify(channelId.hashCode() + (int) bookingId, builder.build());
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/util/ReminderScheduler.java
+++ b/app/src/main/java/com/example/myapplication/util/ReminderScheduler.java
@@ -1,0 +1,66 @@
+package com.example.myapplication.util;
+
+import android.content.Context;
+
+import androidx.work.Data;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+
+import com.example.myapplication.data.model.BookingResponse;
+import com.example.myapplication.data.work.ActivityReminderWorker;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Programa con WorkManager el recordatorio que se dispara 24 h antes de cada
+ * actividad confirmada (Feature 12, requisito 29).
+ */
+public final class ReminderScheduler {
+
+    private static final long REMINDER_LEAD_MILLIS = TimeUnit.HOURS.toMillis(24);
+    private static final String WORK_PREFIX = "reminder_booking_";
+
+    private ReminderScheduler() {}
+
+    /** Programa (o reprograma) los recordatorios de una lista de reservas confirmadas. */
+    public static void scheduleAll(Context context, List<BookingResponse> bookings) {
+        if (bookings == null) return;
+        for (BookingResponse b : bookings) {
+            if (b != null && b.id != null && "CONFIRMED".equalsIgnoreCase(b.status)) {
+                schedule(context, b.id, b.activityName, b.sessionStartTime);
+            }
+        }
+    }
+
+    /**
+     * Programa el recordatorio de una reserva. Si la actividad comienza en menos
+     * de 24 h (o ya pasó) no se agenda nada: la ventana del recordatorio ya venció.
+     */
+    public static void schedule(Context context, long bookingId, String activityName, String sessionStartTime) {
+        long startMillis = FormatUtils.parseToEpochMillis(sessionStartTime);
+        if (startMillis <= 0) return;
+
+        long delay = startMillis - REMINDER_LEAD_MILLIS - System.currentTimeMillis();
+        if (delay <= 0) return;
+
+        Data input = new Data.Builder()
+                .putLong(ActivityReminderWorker.KEY_BOOKING_ID, bookingId)
+                .putString(ActivityReminderWorker.KEY_ACTIVITY_NAME, activityName)
+                .build();
+
+        OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(ActivityReminderWorker.class)
+                .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+                .setInputData(input)
+                .build();
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_PREFIX + bookingId, ExistingWorkPolicy.REPLACE, request);
+    }
+
+    /** Cancela el recordatorio de una reserva (p. ej. si se cancela la actividad). */
+    public static void cancel(Context context, long bookingId) {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_PREFIX + bookingId);
+    }
+}

--- a/app/src/main/res/drawable/ic_error_circle.xml
+++ b/app/src/main/res/drawable/ic_error_circle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#D50000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16.24,7.76l-1.41,-1.41L12,9.17 9.17,6.34 7.76,7.76 10.59,10.59l-2.83,2.83 1.41,1.41L12,12l2.83,2.83 1.41,-1.41 -2.83,-2.83z" />
+</vector>

--- a/app/src/main/res/layout/fragment_check_in_scan.xml
+++ b/app/src/main/res/layout/fragment_check_in_scan.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#000000">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- ── Texto de ayuda (arriba) ── -->
+    <TextView
+        android:id="@+id/tvHint"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:padding="14dp"
+        android:background="#99000000"
+        android:gravity="center"
+        android:text="@string/checkin_hint"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- ── Panel de resultado (verde/rojo), oculto hasta escanear ── -->
+    <LinearLayout
+        android:id="@+id/resultPanel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="28dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="visible">
+
+        <ImageView
+            android:id="@+id/ivResultIcon"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
+            android:src="@drawable/ic_check_circle"
+            android:contentDescription="@null" />
+
+        <TextView
+            android:id="@+id/tvResultTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textColor="#FFFFFF"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            tools:text="@string/checkin_success_title" />
+
+        <TextView
+            android:id="@+id/tvResultMessage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:textColor="#FFFFFF"
+            android:textSize="15sp"
+            tools:text="@string/checkin_success_message" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnScanAgain"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/checkin_scan_again"
+            android:textColor="#FFFFFF"
+            app:strokeColor="#FFFFFF" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_voucher.xml
+++ b/app/src/main/res/layout/fragment_voucher.xml
@@ -60,6 +60,49 @@
             </LinearLayout>
 
             <!-- ── Nombre actividad ── -->
+            <LinearLayout
+                android:id="@+id/voucher_checkin_confirmed_banner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:background="#E8F5E9"
+                android:padding="14dp"
+                android:layout_marginBottom="20dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@drawable/ic_check_circle"
+                    android:contentDescription="@null" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="12dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_checkin_confirmed_title"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:textColor="#1B5E20" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/voucher_checkin_confirmed_subtitle"
+                        android:textSize="13sp"
+                        android:textColor="#388E3C" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
             <TextView
                 android:id="@+id/voucher_activity_name"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_voucher.xml
+++ b/app/src/main/res/layout/fragment_voucher.xml
@@ -452,13 +452,30 @@
 
     </androidx.core.widget.NestedScrollView>
 
+    <!-- ── Botón Check-in por QR (Feature 11) ── -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/voucher_checkin_button"
+        style="@style/Widget.Material3.Button.OutlinedButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/checkin_button"
+        android:textSize="15sp"
+        app:icon="@drawable/ic_ticket"
+        app:iconGravity="textStart" />
+
     <!-- ── Botón Descargar voucher ── -->
     <com.google.android.material.button.MaterialButton
         android:id="@+id/voucher_download_button"
         style="@style/Widget.Material3.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
         android:text="@string/voucher_download_button"
         android:textSize="15sp"
         app:icon="@drawable/ic_download"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -275,6 +275,31 @@
         <argument
             android:name="bookingId"
             app:argType="long" />
+        <action
+            android:id="@+id/action_voucherFragment_to_checkInScanFragment"
+            app:destination="@id/checkInScanFragment" />
+    </fragment>
+
+    <!-- Check-in por QR (Feature 11) -->
+    <fragment
+        android:id="@+id/checkInScanFragment"
+        android:name="com.example.myapplication.ui.checkin.CheckInScanFragment"
+        android:label="@string/checkin_title"
+        tools:layout="@layout/fragment_check_in_scan">
+        <argument
+            android:name="voucherCode"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null" />
+        <argument
+            android:name="sessionId"
+            app:argType="long"
+            android:defaultValue="-1L" />
+        <argument
+            android:name="activityName"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,4 +336,29 @@
 
     <!-- Voucher -->
     <string name="voucher_label_meeting_point">Punto de encuentro</string>
+
+    <!-- Check-in por QR (Feature 11) -->
+    <string name="checkin_button">Confirmar asistencia (escanear QR)</string>
+    <string name="checkin_title">Check-in</string>
+    <string name="checkin_hint">Apuntá la cámara al código QR que muestra el guía</string>
+    <string name="checkin_permission_denied">Se necesita el permiso de cámara para escanear el QR</string>
+    <string name="checkin_success_title">¡Asistencia confirmada!</string>
+    <string name="checkin_success_message">Tu presencia en %1$s quedó registrada. ¡Disfrutá la actividad!</string>
+    <string name="checkin_error_title">QR inválido</string>
+    <string name="checkin_error_message">Este código no corresponde a tu reserva. Pedile al guía el QR de esta actividad.</string>
+    <string name="checkin_scan_again">Escanear de nuevo</string>
+
+    <!-- Recordatorios y Avisos (Feature 12) -->
+    <string name="notif_channel_reminders_name">Recordatorios de actividades</string>
+    <string name="notif_channel_reminders_desc">Avisos 24 h antes de cada actividad reservada</string>
+    <string name="notif_channel_novedades_name">Novedades de reservas</string>
+    <string name="notif_channel_novedades_desc">Avisos de reprogramación o cancelación de actividades</string>
+    <string name="notif_service_listening">Escuchando novedades de tus reservas…</string>
+    <string name="notif_reminder_title">Recordatorio: %1$s</string>
+    <string name="notif_reminder_text">Tu actividad es mañana. Tocá para ver el voucher.</string>
+    <string name="notif_cancelled_title">Actividad cancelada</string>
+    <string name="notif_cancelled_text">%1$s fue cancelada por la operadora.</string>
+    <string name="notif_rescheduled_title">Actividad reprogramada</string>
+    <string name="notif_rescheduled_text">Cambió el horario de %1$s. Tocá para ver el voucher.</string>
+    <string name="notif_permission_denied">Sin permiso de notificaciones no podremos avisarte sobre tus actividades</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,7 +346,10 @@
     <string name="checkin_success_message">Tu presencia en %1$s quedó registrada. ¡Disfrutá la actividad!</string>
     <string name="checkin_error_title">QR inválido</string>
     <string name="checkin_error_message">Este código no corresponde a tu reserva. Pedile al guía el QR de esta actividad.</string>
-    <string name="checkin_scan_again">Escanear de nuevo</string>
+    <string name="checkin_scan_again">Volver</string>
+    <string name="voucher_checkin_confirmed_title">Asistencia confirmada</string>
+    <string name="voucher_checkin_confirmed_subtitle">Tu check-in para esta actividad ya fue registrado.</string>
+    <string name="voucher_checkin_confirmed_button">Asistencia confirmada</string>
 
     <!-- Recordatorios y Avisos (Feature 12) -->
     <string name="notif_channel_reminders_name">Recordatorios de actividades</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ activity = "1.10.0"
 glide = "4.16.0"
 hilt = "2.51.1"
 playServicesMaps = "18.2.0"
+camerax = "1.4.1"
+mlkitBarcode = "17.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +37,11 @@ glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", versi
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
+camera-core = { group = "androidx.camera", name = "camera-core", version.ref = "camerax" }
+camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
+camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
+camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
+mlkit-barcode = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkitBarcode" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Voucher digital + Check-in por QR y Recordatorios/Avisos (Features 11 y 12)

### Resumen

Agrega las dos features pedidas, replicando los patrones de la implementación de referencia de `mobile-practices-android` (CameraX + ML Kit para QR, y Foreground Service + NotificationChannel para avisos), adaptados al dominio de XploreNow.

### Feature 11 — Voucher Digital y Check-in por QR (Cámara)

- **Voucher digital** (req. 26): muestra nombre de actividad, fecha/horario, punto de encuentro, guía y cantidad de participantes.
- **Check-in por QR** (req. 27): nuevo `CheckInScanFragment` con CameraX + ML Kit. Desde el voucher, el viajero abre la cámara y escanea el QR que muestra el guía.
- **Resultado visual claro** (req. 28): panel **verde** + ícono de check si el QR corresponde a la reserva, **rojo** + ícono de error si es inválido, con mensaje descriptivo y opción de reintentar. El QR se valida localmente contra la reserva (código de voucher o `sessionId`, en texto plano o JSON).

### Feature 12 — Recordatorios y Avisos (Notificaciones)

- **Recordatorio 24 h antes** (req. 29): `ReminderScheduler` + `ActivityReminderWorker` (WorkManager) programan una notificación 24 h antes de cada actividad confirmada; el tap lleva directo al voucher.
- **Aviso inmediato de reprogramación/cancelación** (req. 30): `NovedadesPollingService` (foreground service) consulta las reservas y compara contra el último estado conocido para detectar cambios de horario (reprogramación) o paso a `CANCELLED`, notificando al instante.
- `NotificationHelper` centraliza canales y el `PendingIntent` al voucher; `MainActivity` gestiona el permiso runtime `POST_NOTIFICATIONS`, arranca el servicio y maneja el deep-link a la notificación.

### Cambios técnicos

- Dependencias nuevas: CameraX 1.4.1 y ML Kit barcode-scanning 17.3.0 (`libs.versions.toml` + `build.gradle.kts`).
- Permisos: `CAMERA`, `POST_NOTIFICATIONS`, `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`; servicio declarado con `foregroundServiceType="dataSync"`; `MainActivity` en `launchMode="singleTop"`.
- Navegación: destino `checkInScanFragment` + action desde `voucherFragment`.
- WorkManager ya inicializado vía Hilt (`HiltWorkerFactory` en `XploreNowApplication`).

### Backend

No requiere cambios. El check-in se valida en el cliente, el recordatorio es 100% client-side (WorkManager) y los avisos de reprogramación/cancelación se derivan del endpoint de reservas existente (status + horario de inicio).

### Testing

- `./gradlew :app:assembleDebug` compila OK y genera el APK.
- Pendiente de prueba manual en dispositivo/emulador: escaneo de QR (cámara) y disparo de notificaciones.
